### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @kyleknap @jalauzon-msft @vincenttran-msft @seanmcc-msft


### PR DESCRIPTION
It allows us to automatically assign a designated set of reviewers for PRs and require their approval before merging into main. For now, we'll be assigning the core set of reviewers to all files in the repository. More information can be found in the GitHub docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners