### PR TITLE
Add publish workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: Run CI
-on: [push, pull_request]
+on: [push, pull_request, workflow_call]
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,42 @@
+name: Publish release
+on:
+  workflow_dispatch:
+permissions:
+  id-token: write
+  contents: read
+jobs:
+  run-ci:
+    name: Run CI
+    uses: ./.github/workflows/ci.yml
+  upload:
+    name: Upload to partner blob container
+    needs: run-ci
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Install AzCopy
+        run: |
+          curl -sSL -O https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb
+          sudo dpkg -i packages-microsoft-prod.deb
+          rm packages-microsoft-prod.deb
+          sudo apt-get update
+          sudo apt-get install azcopy
+      - name: Download distributions
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          name: dists
+          path: dist/
+      - name: Get package version
+        run: |
+          azstoragetorch_version=$(ls dist/azstoragetorch-*.whl | head -n 1 | cut -d- -f2)
+          test -n "$azstoragetorch_version"
+          echo "AZSTORAGETORCH_VERSION=$azstoragetorch_version" >> "$GITHUB_ENV"
+      - name: Azure login
+        uses: azure/login@6c251865b4e6290e7b78be643ea2d005bc51f69a
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: Upload distributions to blob container
+        env:
+          AZCOPY_AUTO_LOGIN_TYPE: AZCLI
+        run: azcopy copy 'dist/' "https://azuresdkpartnerdrops.blob.core.windows.net/drops/azstoragetorch/python/$AZSTORAGETORCH_VERSION/" --recursive


### PR DESCRIPTION
Runs CI and then publishes sdist + wheel to partner blob container. It authenticates using the [Azure login GitHub Action over OIDC](https://github.com/marketplace/actions/azure-login#login-with-openid-connect-oidc-recommended). This workflow can only be triggered manually from the `main` branch. Note in previous implementations, I was using the [Azure CLI to do the uploads](https://github.com/kyleknap/azure-storage-for-pytorch/blob/b495c3d8c446c2b23f8c075dfc70facc64ef408e/.github/workflows/publish.yml#L32-L46), but I switched to using AzCopy to simplify the commands needed to upload the distributions.