### PR TITLE
Remove dist directory from container upload

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,4 +39,4 @@ jobs:
       - name: Upload distributions to blob container
         env:
           AZCOPY_AUTO_LOGIN_TYPE: AZCLI
-        run: azcopy copy 'dist/' "https://azuresdkpartnerdrops.blob.core.windows.net/drops/azstoragetorch/python/$AZSTORAGETORCH_VERSION/" --recursive
+        run: azcopy copy 'dist/*' "https://azuresdkpartnerdrops.blob.core.windows.net/drops/azstoragetorch/python/$AZSTORAGETORCH_VERSION/" --recursive


### PR DESCRIPTION
The asterisk ensures we do not include a `dist` in the final blob path so we get `azstorage/python/<version>/<artifact-name>` instead of `azstorage/python/<version>/dist/<artifact-name>`.

I had this in my POC, which worked correctly, but forgot to port it back to the branch used for the PR with the official resources.