### PR TITLE
Implement `read()` for BlobIO

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 ]
 dependencies = [
     "azure-identity<2",
+    "azure-storage-blob<13"
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,11 @@ classifiers = [
 ]
 dependencies = [
     "azure-identity<2",
-    "azure-storage-blob<13"
+    # This is pinned because the library uses internal APIs of the blob SDK and helps
+    # avoid automatically breaking the library if a new version of the SDK breaks the
+    # internal API. As new versions of the SDK are released, the ceiling of this version
+    # range should be updated to match the new version.
+    "azure-storage-blob>=12.24.0,<=12.24.1"
 ]
 dynamic = ["version"]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,9 +14,9 @@ azure-identity==1.19.0 \
     --hash=sha256:500144dc18197d7019b81501165d4fa92225f03778f17d7ca8a2a180129a9c83 \
     --hash=sha256:e3f6558c181692d7509f09de10cca527c7dce426776454fb97df512a46527e81
     # via azstoragetorch (pyproject.toml)
-azure-storage-blob==12.24.0 \
-    --hash=sha256:4f0bb4592ea79a2d986063696514c781c9e62be240f09f6397986e01755bc071 \
-    --hash=sha256:eaaaa1507c8c363d6e1d1342bd549938fdf1adec9b1ada8658c8f5bf3aea844e
+azure-storage-blob==12.24.1 \
+    --hash=sha256:052b2a1ea41725ba12e2f4f17be85a54df1129e13ea0321f5a2fcc851cbf47d4 \
+    --hash=sha256:77fb823fdbac7f3c11f7d86a5892e2f85e161e8440a7489babe2195bf248f09e
     # via azstoragetorch (pyproject.toml)
 build==1.2.1 \
     --hash=sha256:526263f4870c26f26c433545579475377b2b7588b6f1eac76a001e873ae3e19d \

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,10 +7,16 @@
 azure-core==1.31.0 \
     --hash=sha256:22954de3777e0250029360ef31d80448ef1be13b80a459bff80ba7073379e2cd \
     --hash=sha256:656a0dd61e1869b1506b7c6a3b31d62f15984b1a573d6326f6aa2f3e4123284b
-    # via azure-identity
+    # via
+    #   azure-identity
+    #   azure-storage-blob
 azure-identity==1.19.0 \
     --hash=sha256:500144dc18197d7019b81501165d4fa92225f03778f17d7ca8a2a180129a9c83 \
     --hash=sha256:e3f6558c181692d7509f09de10cca527c7dce426776454fb97df512a46527e81
+    # via azstoragetorch (pyproject.toml)
+azure-storage-blob==12.24.0 \
+    --hash=sha256:4f0bb4592ea79a2d986063696514c781c9e62be240f09f6397986e01755bc071 \
+    --hash=sha256:eaaaa1507c8c363d6e1d1342bd549938fdf1adec9b1ada8658c8f5bf3aea844e
     # via azstoragetorch (pyproject.toml)
 build==1.2.1 \
     --hash=sha256:526263f4870c26f26c433545579475377b2b7588b6f1eac76a001e873ae3e19d \
@@ -238,6 +244,7 @@ cryptography==43.0.3 \
     --hash=sha256:f7b178f11ed3664fd0e995a47ed2b5ff0a12d893e41dd0494f406d1cf555cab7
     # via
     #   azure-identity
+    #   azure-storage-blob
     #   msal
     #   pyjwt
 exceptiongroup==1.2.2 \
@@ -256,6 +263,10 @@ iniconfig==2.0.0 \
     --hash=sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3 \
     --hash=sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374
     # via pytest
+isodate==0.7.2 \
+    --hash=sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15 \
+    --hash=sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6
+    # via azure-storage-blob
 msal==1.31.0 \
     --hash=sha256:2c4f189cf9cc8f00c80045f66d39b7c0f3ed45873fd3d1f2af9f22db2e12ff4b \
     --hash=sha256:96bc37cff82ebe4b160d5fc0f1196f6ca8b50e274ecd0ec5bf69c438514086e7
@@ -341,6 +352,7 @@ typing-extensions==4.12.2 \
     # via
     #   azure-core
     #   azure-identity
+    #   azure-storage-blob
 urllib3==2.2.3 \
     --hash=sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac \
     --hash=sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9

--- a/src/azstoragetorch/_client.py
+++ b/src/azstoragetorch/_client.py
@@ -1,0 +1,146 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+import concurrent.futures
+import functools
+import io
+import logging
+import math
+from typing import Optional, List, Tuple, Iterator, Union
+
+from azure.core.credentials import (
+    AzureSasCredential,
+    TokenCredential,
+)
+import azure.core.exceptions
+import azure.storage.blob
+import azure.storage.blob._generated.models
+from azure.storage.blob._shared.response_handlers import process_storage_error
+
+
+_LOGGER = logging.getLogger(__name__)
+
+SDK_CREDENTIAL_TYPE = Optional[
+    Union[
+        AzureSasCredential,
+        TokenCredential,
+    ]
+]
+
+
+class AzStorageTorchBlobClient:
+    _CONNECTION_DATA_BLOCK_SIZE = 256 * 1024
+    _PARTITIONED_DOWNLOAD_THRESHOLD = 16 * 1024 * 1024
+    _PARTITION_SIZE = 16 * 1024 * 1024
+    _RETRYABLE_READ_EXCEPTIONS = (
+        azure.core.exceptions.IncompleteReadError,
+        azure.core.exceptions.HttpResponseError,
+        azure.core.exceptions.DecodeError,
+    )
+
+    def __init__(
+        self,
+        sdk_blob_client: azure.storage.blob.BlobClient,
+        executor: Optional[concurrent.futures.Executor] = None,
+    ):
+        self._sdk_blob_client = sdk_blob_client
+        self._generated_sdk_storage_client = self._sdk_blob_client._client
+        if executor is None:
+            executor = concurrent.futures.ThreadPoolExecutor()
+        self._executor = executor
+
+    @classmethod
+    def from_blob_url(
+        cls, blob_url: str, sdk_credential: SDK_CREDENTIAL_TYPE
+    ) -> "AzStorageTorchBlobClient":
+        sdk_blob_client = azure.storage.blob.BlobClient.from_blob_url(
+            blob_url,
+            credential=sdk_credential,
+            connection_data_block_size=cls._CONNECTION_DATA_BLOCK_SIZE,
+        )
+        return AzStorageTorchBlobClient(sdk_blob_client)
+
+    def get_blob_size(self) -> int:
+        return self._blob_properties.size
+
+    def download(self, offset: int = 0, length: Optional[int] = None) -> bytes:
+        length = self._update_download_length_from_blob_size(offset, length)
+        if length < self._PARTITIONED_DOWNLOAD_THRESHOLD:
+            return self._download_with_retries(offset, length)
+        else:
+            return self._partitioned_download(offset, length)
+
+    def close(self) -> None:
+        self._executor.shutdown()
+
+    @functools.cached_property
+    def _blob_properties(self) -> azure.storage.blob.BlobProperties:
+        return self._sdk_blob_client.get_blob_properties()
+
+    def _update_download_length_from_blob_size(
+        self, offset: int, length: Optional[int] = None
+    ) -> int:
+        length_from_offset = self.get_blob_size() - offset
+        if length is not None:
+            return min(length, length_from_offset)
+        return length_from_offset
+
+    def _partitioned_download(self, offset: int, length: int) -> bytes:
+        futures = []
+        for partition in self._get_partitioned_reads(offset, length):
+            futures.append(
+                self._executor.submit(self._download_with_retries, *partition)
+            )
+        return b"".join(f.result() for f in futures)
+
+    def _get_partitioned_reads(self, offset: int, length: int) -> List[Tuple[int, int]]:
+        end = offset + length
+        num_partitions = math.ceil(length / self._PARTITION_SIZE)
+        partitions = []
+        for i in range(num_partitions):
+            start = offset + i * self._PARTITION_SIZE
+            if start >= end:
+                break
+            size = min(self._PARTITION_SIZE, end - start)
+            partitions.append((start, size))
+        return partitions
+
+    def _download_with_retries(self, pos: int, length: int) -> bytes:
+        attempts_remaining = 3
+        while attempts_remaining > 0:
+            stream = self._get_download_stream(pos, length)
+            try:
+                return self._read_stream(stream)
+            except self._RETRYABLE_READ_EXCEPTIONS:
+                attempts_remaining -= 1
+                if not attempts_remaining:
+                    raise
+                _LOGGER.debug(
+                    "Retrying download from caught streaming exception (attempts remaining: %s).",
+                    attempts_remaining,
+                    exc_info=True,
+                )
+
+    def _get_download_stream(self, pos: int, length: int) -> Iterator[bytes]:
+        try:
+            return self._generated_sdk_storage_client.blob.download(
+                range=f"bytes={pos}-{pos + length - 1}",
+                modified_access_conditions=azure.storage.blob._generated.models.ModifiedAccessConditions(
+                    if_match=self._blob_properties.etag
+                ),
+            )
+        except azure.core.exceptions.HttpResponseError as e:
+            # TODO: This is so that we properly map exceptions from the generated client to the correct
+            # exception class and error code. In the future, prior to a GA, we should consider pulling
+            # in this function or a derivative of it if we plan to continue to raise Azure Python SDK
+            # exceptions from this library (i.e. instead of raising our own exception classes).
+            process_storage_error(e)
+
+    def _read_stream(self, stream: Iterator[bytes]) -> bytes:
+        content = io.BytesIO()
+        for chunk in stream:
+            content.write(chunk)
+        return content.getvalue()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+import pytest
+
+
+@pytest.fixture
+def blob_url():
+    return "https://myaccount.blob.core.windows.net/mycontainer/myblob"
+
+
+@pytest.fixture
+def blob_content():
+    return b"blob content"
+
+
+@pytest.fixture
+def blob_length(blob_content):
+    return len(blob_content)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,394 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in the project root for
+# license information.
+# --------------------------------------------------------------------------
+import concurrent.futures
+from unittest import mock
+import os
+import pytest
+
+from azure.core.credentials import AzureSasCredential
+import azure.core.exceptions
+from azure.core.pipeline.transport import HttpRequest, HttpResponse
+from azure.storage.blob import BlobClient, BlobProperties, StorageErrorCode
+from azure.storage.blob._generated._azure_blob_storage import AzureBlobStorage
+from azure.storage.blob._generated.operations import BlobOperations
+from azure.storage.blob._generated.models import ModifiedAccessConditions
+
+from azstoragetorch._client import AzStorageTorchBlobClient
+
+MB = 1024 * 1024
+DEFAULT_PARTITION_DOWNLOAD_THRESHOLD = 16 * MB
+DEFAULT_PARTITION_SIZE = 16 * MB
+EXPECTED_RETRYABLE_READ_EXCEPTIONS = [
+    azure.core.exceptions.IncompleteReadError,
+    azure.core.exceptions.HttpResponseError,
+    azure.core.exceptions.DecodeError,
+]
+
+
+@pytest.fixture
+def blob_etag():
+    return "blob-etag"
+
+
+@pytest.fixture
+def blob_properties(blob_length, blob_etag):
+    return BlobProperties(**{"Content-Length": blob_length, "ETag": blob_etag})
+
+
+@pytest.fixture
+def mock_generated_sdk_storage_client():
+    mock_generated_sdk_client = mock.Mock(AzureBlobStorage)
+    mock_generated_sdk_client.blob = mock.Mock(BlobOperations)
+    return mock_generated_sdk_client
+
+
+@pytest.fixture
+def mock_sdk_blob_client(mock_generated_sdk_storage_client):
+    mock_sdk_client = mock.Mock(BlobClient)
+    mock_sdk_client._client = mock_generated_sdk_storage_client
+    return mock_sdk_client
+
+
+@pytest.fixture
+def single_threaded_executor():
+    return concurrent.futures.ThreadPoolExecutor(max_workers=1)
+
+
+@pytest.fixture
+def azstoragetorch_blob_client(mock_sdk_blob_client, single_threaded_executor):
+    return AzStorageTorchBlobClient(
+        mock_sdk_blob_client, executor=single_threaded_executor
+    )
+
+
+@pytest.fixture
+def http_response_error(blob_url):
+    mock_http_response = mock.Mock(HttpResponse)
+    mock_http_response.reason = "message"
+    mock_http_response.status_code = 400
+    mock_http_response.headers = {}
+    mock_http_response.content_type = "application/xml"
+    mock_http_response.text.return_value = ""
+    return azure.core.exceptions.HttpResponseError(response=mock_http_response)
+
+
+def random_bytes(length):
+    return os.urandom(length)
+
+
+def slice_bytes(content, range_value):
+    start, end = range_value.split("-")
+    return content[int(start) : int(end) + 1]
+
+
+def to_bytes_iterator(content, chunk_size=64 * 1024, exception_to_raise=None):
+    for i in range(0, len(content), chunk_size):
+        yield content[i : i + chunk_size]
+        if exception_to_raise is not None:
+            raise exception_to_raise
+
+
+class NonRetryableException(Exception):
+    pass
+
+
+class TestAzStorageTorchBlobClient:
+    def assert_expected_download_calls(
+        self, mock_generated_sdk_storage_client, expected_ranges, expected_etag
+    ):
+        expected_download_calls = [
+            mock.call(
+                range=f"bytes={expected_range}",
+                modified_access_conditions=ModifiedAccessConditions(
+                    if_match=expected_etag
+                ),
+            )
+            for expected_range in expected_ranges
+        ]
+        assert (
+            mock_generated_sdk_storage_client.blob.download.call_args_list
+            == expected_download_calls
+        )
+
+    def test_from_blob_url(self, blob_url, mock_sdk_blob_client):
+        credential = AzureSasCredential("sas")
+        with mock.patch("azure.storage.blob.BlobClient") as patched_sdk_blob_client:
+            client = AzStorageTorchBlobClient.from_blob_url(blob_url, credential)
+            assert isinstance(client, AzStorageTorchBlobClient)
+            patched_sdk_blob_client.from_blob_url.assert_called_once_with(
+                blob_url,
+                credential=credential,
+                connection_data_block_size=256 * 1024,
+            )
+
+    def test_get_blob_size(
+        self, azstoragetorch_blob_client, mock_sdk_blob_client, blob_properties
+    ):
+        mock_sdk_blob_client.get_blob_properties.return_value = blob_properties
+        assert azstoragetorch_blob_client.get_blob_size() == blob_properties.size
+        mock_sdk_blob_client.get_blob_properties.assert_called_once_with()
+
+    def test_get_blob_size_caches_result(
+        self, azstoragetorch_blob_client, mock_sdk_blob_client, blob_properties
+    ):
+        mock_sdk_blob_client.get_blob_properties.return_value = blob_properties
+        assert azstoragetorch_blob_client.get_blob_size() == blob_properties.size
+        assert azstoragetorch_blob_client.get_blob_size() == blob_properties.size
+        mock_sdk_blob_client.get_blob_properties.assert_called_once_with()
+
+    def test_close(self, mock_sdk_blob_client):
+        mock_executor = mock.Mock(concurrent.futures.Executor)
+        client = AzStorageTorchBlobClient(mock_sdk_blob_client, mock_executor)
+        client.close()
+        mock_executor.shutdown.assert_called_once_with()
+
+    @pytest.mark.parametrize(
+        "blob_size, download_offset, download_length, expected_ranges",
+        [
+            # Small single GET full, download
+            (10, None, None, ["0-9"]),
+            # Small download with offset
+            (10, 5, None, ["5-9"]),
+            # Small download with length
+            (10, 0, 5, ["0-4"]),
+            # Small download with offset and length
+            (10, 3, 4, ["3-6"]),
+            # Small download with length past blob size
+            (10, 5, 10, ["5-9"]),
+            # Small download of portion of large blob
+            (32 * MB, 10, 10, ["10-19"]),
+            # Download just below partitioned threshold
+            (
+                DEFAULT_PARTITION_DOWNLOAD_THRESHOLD - 1,
+                None,
+                None,
+                [f"0-{DEFAULT_PARTITION_DOWNLOAD_THRESHOLD - 2}"],
+            ),
+            # Download at partitioned threshold
+            (
+                DEFAULT_PARTITION_DOWNLOAD_THRESHOLD,
+                None,
+                None,
+                [f"0-{DEFAULT_PARTITION_DOWNLOAD_THRESHOLD - 1}"],
+            ),
+            # Download just above partitioned threshold
+            (
+                DEFAULT_PARTITION_DOWNLOAD_THRESHOLD + 1,
+                None,
+                None,
+                [
+                    f"0-{DEFAULT_PARTITION_DOWNLOAD_THRESHOLD - 1}",
+                    f"{DEFAULT_PARTITION_DOWNLOAD_THRESHOLD}-{DEFAULT_PARTITION_DOWNLOAD_THRESHOLD}",
+                ],
+            ),
+            # Large download with multiple partitions
+            (
+                4 * DEFAULT_PARTITION_SIZE,
+                None,
+                None,
+                [
+                    f"0-{DEFAULT_PARTITION_SIZE - 1}",
+                    f"{DEFAULT_PARTITION_SIZE}-{2 * DEFAULT_PARTITION_SIZE - 1}",
+                    f"{2 * DEFAULT_PARTITION_SIZE}-{3 * DEFAULT_PARTITION_SIZE - 1}",
+                    f"{3 * DEFAULT_PARTITION_SIZE}-{4 * DEFAULT_PARTITION_SIZE - 1}",
+                ],
+            ),
+            # Large download with offset
+            (
+                4 * DEFAULT_PARTITION_SIZE,
+                10,
+                None,
+                [
+                    f"10-{10 + (DEFAULT_PARTITION_SIZE - 1)}",
+                    f"{10 + DEFAULT_PARTITION_SIZE}-{10 + (2 * DEFAULT_PARTITION_SIZE - 1)}",
+                    f"{10 + (2 * DEFAULT_PARTITION_SIZE)}-{10 + (3 * DEFAULT_PARTITION_SIZE - 1)}",
+                    f"{10 + (3 * DEFAULT_PARTITION_SIZE)}-{4 * DEFAULT_PARTITION_SIZE - 1}",
+                ],
+            ),
+            # Large download with length
+            (
+                4 * DEFAULT_PARTITION_SIZE,
+                None,
+                2 * DEFAULT_PARTITION_SIZE + 5,
+                [
+                    f"0-{DEFAULT_PARTITION_SIZE - 1}",
+                    f"{DEFAULT_PARTITION_SIZE}-{2 * DEFAULT_PARTITION_SIZE - 1}",
+                    f"{2 * DEFAULT_PARTITION_SIZE}-{2 * DEFAULT_PARTITION_SIZE + 4}",
+                ],
+            ),
+            # Large download with offset and length
+            (
+                4 * DEFAULT_PARTITION_SIZE,
+                10,
+                2 * DEFAULT_PARTITION_SIZE + 5,
+                [
+                    f"10-{10 + (DEFAULT_PARTITION_SIZE - 1)}",
+                    f"{10 + DEFAULT_PARTITION_SIZE}-{10 + (2 * DEFAULT_PARTITION_SIZE - 1)}",
+                    f"{10 + (2 * DEFAULT_PARTITION_SIZE)}-{10 + (2 * DEFAULT_PARTITION_SIZE + 4)}",
+                ],
+            ),
+            # Large download with length past blob size
+            (
+                4 * DEFAULT_PARTITION_SIZE,
+                10,
+                5 * DEFAULT_PARTITION_SIZE,
+                [
+                    f"10-{10 + (DEFAULT_PARTITION_SIZE - 1)}",
+                    f"{10 + DEFAULT_PARTITION_SIZE}-{10 + (2 * DEFAULT_PARTITION_SIZE - 1)}",
+                    f"{10 + (2 * DEFAULT_PARTITION_SIZE)}-{10 + (3 * DEFAULT_PARTITION_SIZE - 1)}",
+                    f"{10 + (3 * DEFAULT_PARTITION_SIZE)}-{4 * DEFAULT_PARTITION_SIZE - 1}",
+                ],
+            ),
+        ],
+    )
+    def test_download(
+        self,
+        blob_size,
+        download_offset,
+        download_length,
+        expected_ranges,
+        azstoragetorch_blob_client,
+        mock_sdk_blob_client,
+        mock_generated_sdk_storage_client,
+        blob_properties,
+    ):
+        blob_properties.size = blob_size
+        mock_sdk_blob_client.get_blob_properties.return_value = blob_properties
+
+        content = random_bytes(blob_size)
+        mock_generated_sdk_storage_client.blob.download.side_effect = [
+            to_bytes_iterator(slice_bytes(content, expected_range))
+            for expected_range in expected_ranges
+        ]
+        download_kwargs = {}
+        expected_download_content = content
+        if download_offset is not None:
+            download_kwargs["offset"] = download_offset
+            expected_download_content = expected_download_content[download_offset:]
+        if download_length is not None:
+            download_kwargs["length"] = download_length
+            expected_download_content = expected_download_content[:download_length]
+        assert (
+            azstoragetorch_blob_client.download(**download_kwargs)
+            == expected_download_content
+        )
+        self.assert_expected_download_calls(
+            mock_generated_sdk_storage_client,
+            expected_ranges=expected_ranges,
+            expected_etag=blob_properties.etag,
+        )
+
+    @pytest.mark.parametrize(
+        "response_error_code,expected_sdk_exception,expected_storage_error_code",
+        [
+            (
+                "BlobNotFound",
+                azure.core.exceptions.ResourceNotFoundError,
+                StorageErrorCode.BLOB_NOT_FOUND,
+            ),
+            (
+                "ConditionNotMet",
+                azure.core.exceptions.ResourceModifiedError,
+                StorageErrorCode.CONDITION_NOT_MET,
+            ),
+        ],
+    )
+    def test_maps_download_exceptions(
+        self,
+        azstoragetorch_blob_client,
+        mock_sdk_blob_client,
+        mock_generated_sdk_storage_client,
+        blob_properties,
+        http_response_error,
+        response_error_code,
+        expected_sdk_exception,
+        expected_storage_error_code,
+    ):
+        http_response_error.response.text.return_value = (
+            f'<?xml version="1.0" encoding="utf-8"?>'
+            f" <Error><Code>{response_error_code}</Code>"
+            f" <Message>message</Message>"
+            f"</Error>"
+        )
+
+        mock_sdk_blob_client.get_blob_properties.return_value = blob_properties
+        mock_generated_sdk_storage_client.blob.download.side_effect = (
+            http_response_error
+        )
+        with pytest.raises(expected_sdk_exception) as exc_info:
+            azstoragetorch_blob_client.download()
+        assert exc_info.value.error_code == expected_storage_error_code
+
+    @pytest.mark.parametrize(
+        "retryable_exception_cls", EXPECTED_RETRYABLE_READ_EXCEPTIONS
+    )
+    def test_retries_reads(
+        self,
+        retryable_exception_cls,
+        azstoragetorch_blob_client,
+        mock_sdk_blob_client,
+        mock_generated_sdk_storage_client,
+        blob_properties,
+    ):
+        content = random_bytes(10)
+        blob_properties.size = len(content)
+        mock_sdk_blob_client.get_blob_properties.return_value = blob_properties
+        mock_generated_sdk_storage_client.blob.download.side_effect = [
+            to_bytes_iterator(content, exception_to_raise=retryable_exception_cls()),
+            to_bytes_iterator(content),
+        ]
+        assert azstoragetorch_blob_client.download() == content
+        self.assert_expected_download_calls(
+            mock_generated_sdk_storage_client, ["0-9", "0-9"], blob_properties.etag
+        )
+
+    @pytest.mark.parametrize(
+        "retryable_exception_cls", EXPECTED_RETRYABLE_READ_EXCEPTIONS
+    )
+    def test_raises_after_retries_exhausted(
+        self,
+        retryable_exception_cls,
+        azstoragetorch_blob_client,
+        mock_sdk_blob_client,
+        mock_generated_sdk_storage_client,
+        blob_properties,
+    ):
+        content = random_bytes(10)
+        blob_properties.size = len(content)
+        mock_sdk_blob_client.get_blob_properties.return_value = blob_properties
+        mock_generated_sdk_storage_client.blob.download.side_effect = [
+            to_bytes_iterator(content, exception_to_raise=retryable_exception_cls()),
+            to_bytes_iterator(content, exception_to_raise=retryable_exception_cls()),
+            to_bytes_iterator(content, exception_to_raise=retryable_exception_cls()),
+        ]
+        with pytest.raises(retryable_exception_cls):
+            azstoragetorch_blob_client.download()
+        self.assert_expected_download_calls(
+            mock_generated_sdk_storage_client,
+            ["0-9", "0-9", "0-9"],
+            blob_properties.etag,
+        )
+
+    def test_does_not_retry_on_non_retryable_exceptions(
+        self,
+        azstoragetorch_blob_client,
+        mock_sdk_blob_client,
+        mock_generated_sdk_storage_client,
+        blob_properties,
+    ):
+        content = random_bytes(10)
+        blob_properties.size = len(content)
+        mock_sdk_blob_client.get_blob_properties.return_value = blob_properties
+        mock_generated_sdk_storage_client.blob.download.side_effect = [
+            to_bytes_iterator(content, exception_to_raise=NonRetryableException()),
+        ]
+        with pytest.raises(NonRetryableException):
+            azstoragetorch_blob_client.download()
+        self.assert_expected_download_calls(
+            mock_generated_sdk_storage_client,
+            ["0-9"],
+            blob_properties.etag,
+        )

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -11,16 +11,7 @@ from azure.core.credentials import AzureSasCredential, AzureNamedKeyCredential
 from azure.identity import DefaultAzureCredential
 
 from azstoragetorch.io import BlobIO
-
-
-@pytest.fixture
-def blob_url():
-    return "https://myaccount.blob.core.windows.net/mycontainer/myblob"
-
-
-@pytest.fixture
-def blob_content():
-    return b"blob content"
+from azstoragetorch._client import AzStorageTorchBlobClient
 
 
 @pytest.fixture
@@ -29,34 +20,36 @@ def sas_token():
 
 
 @pytest.fixture
-def blob_length(blob_content):
-    return len(blob_content)
+def mock_azstoragetorch_blob_client(blob_content, blob_length):
+    mock_blob_client = mock.Mock(AzStorageTorchBlobClient)
+    mock_blob_client.from_blob_url.return_value = mock_blob_client
+    mock_blob_client.get_blob_size.return_value = blob_length
+    mock_blob_client.download.return_value = blob_content
+    return mock_blob_client
 
 
 @pytest.fixture
-def blob_io(blob_url):
-    return BlobIO(blob_url, mode="rb")
-
-
-# Note: Not ideal to be patching a private class, but this is needed until the _BlobDownloader class is
-# fleshed out and no longer raising NotImplementedErrors. We should be able to switch this patch to the Blob SDK client
-# or remove the patch entirely if we allow BlobIO to accept different types of downloaders.
-@pytest.fixture(autouse=True)
-def mock_blob_downloader(blob_content, blob_length):
-    with mock.patch("azstoragetorch.io._BlobDownloader", spec=True) as mock_downloader:
-        mock_downloader.return_value = mock_downloader
-        mock_downloader.get_blob_size.return_value = blob_length
-        mock_downloader.download.return_value = blob_content
-        yield mock_downloader
+def blob_io(blob_url, mock_azstoragetorch_blob_client):
+    return BlobIO(
+        blob_url,
+        mode="rb",
+        azstoragetorch_blob_client_cls=mock_azstoragetorch_blob_client,
+    )
 
 
 class TestBlobIO:
     def test_credential_defaults_to_azure_default_credential(
-        self, blob_url, mock_blob_downloader
+        self, blob_url, mock_azstoragetorch_blob_client
     ):
-        BlobIO(blob_url, mode="rb")
-        mock_blob_downloader.assert_called_once_with(blob_url, mock.ANY)
-        creds = mock_blob_downloader.call_args[0][1]
+        BlobIO(
+            blob_url,
+            mode="rb",
+            azstoragetorch_blob_client_cls=mock_azstoragetorch_blob_client,
+        )
+        mock_azstoragetorch_blob_client.from_blob_url.assert_called_once_with(
+            blob_url, mock.ANY
+        )
+        creds = mock_azstoragetorch_blob_client.from_blob_url.call_args[0][1]
         assert isinstance(creds, DefaultAzureCredential)
 
     @pytest.mark.parametrize(
@@ -67,30 +60,56 @@ class TestBlobIO:
         ],
     )
     def test_respects_user_provided_credential(
-        self, blob_url, mock_blob_downloader, credential
+        self, blob_url, mock_azstoragetorch_blob_client, credential
     ):
-        BlobIO(blob_url, mode="rb", credential=credential)
-        mock_blob_downloader.assert_called_once_with(blob_url, credential)
+        BlobIO(
+            blob_url,
+            mode="rb",
+            credential=credential,
+            azstoragetorch_blob_client_cls=mock_azstoragetorch_blob_client,
+        )
+        mock_azstoragetorch_blob_client.from_blob_url.assert_called_once_with(
+            blob_url, credential
+        )
 
-    def test_anonymous_credential(self, blob_url, mock_blob_downloader):
-        BlobIO(blob_url, mode="rb", credential=False)
-        mock_blob_downloader.assert_called_once_with(blob_url, None)
+    def test_anonymous_credential(self, blob_url, mock_azstoragetorch_blob_client):
+        BlobIO(
+            blob_url,
+            mode="rb",
+            credential=False,
+            azstoragetorch_blob_client_cls=mock_azstoragetorch_blob_client,
+        )
+        mock_azstoragetorch_blob_client.from_blob_url.assert_called_once_with(
+            blob_url, None
+        )
 
     def test_detects_sas_token_in_blob_url(
-        self, blob_url, mock_blob_downloader, sas_token
+        self, blob_url, mock_azstoragetorch_blob_client, sas_token
     ):
-        BlobIO(blob_url + "?" + sas_token, mode="rb")
+        BlobIO(
+            blob_url + "?" + sas_token,
+            mode="rb",
+            azstoragetorch_blob_client_cls=mock_azstoragetorch_blob_client,
+        )
         # The SDK prefers the explict credential over the one in the URL. So if a SAS token is
         # in the URL, we do not want it automatically injecting the DefaultAzureCredential.
-        mock_blob_downloader.assert_called_once_with(blob_url + "?" + sas_token, None)
+        mock_azstoragetorch_blob_client.from_blob_url.assert_called_once_with(
+            blob_url + "?" + sas_token, None
+        )
 
     def test_credential_defaults_to_azure_default_credential_for_snapshot_url(
-        self, blob_url, mock_blob_downloader
+        self, blob_url, mock_azstoragetorch_blob_client
     ):
         snapshot_url = f"{blob_url}?snapshot=2024-10-28T20:34:36.1724588Z"
-        BlobIO(snapshot_url, mode="rb")
-        mock_blob_downloader.assert_called_once_with(snapshot_url, mock.ANY)
-        creds = mock_blob_downloader.call_args[0][1]
+        BlobIO(
+            snapshot_url,
+            mode="rb",
+            azstoragetorch_blob_client_cls=mock_azstoragetorch_blob_client,
+        )
+        mock_azstoragetorch_blob_client.from_blob_url.assert_called_once_with(
+            snapshot_url, mock.ANY
+        )
+        creds = mock_azstoragetorch_blob_client.from_blob_url.call_args[0][1]
         assert isinstance(creds, DefaultAzureCredential)
 
     @pytest.mark.parametrize(
@@ -130,30 +149,34 @@ class TestBlobIO:
         with pytest.raises(ValueError, match="Unsupported mode"):
             BlobIO(blob_url, mode=unsupported_mode)
 
-    def test_close(self, blob_io, mock_blob_downloader):
+    def test_close(self, blob_io, mock_azstoragetorch_blob_client):
         assert not blob_io.closed
         blob_io.close()
         assert blob_io.closed
-        mock_blob_downloader.close.assert_called_once()
+        mock_azstoragetorch_blob_client.close.assert_called_once()
 
-    def test_can_call_close_multiple_times(self, blob_io, mock_blob_downloader):
+    def test_can_call_close_multiple_times(
+        self, blob_io, mock_azstoragetorch_blob_client
+    ):
         blob_io.close()
         blob_io.close()
         assert blob_io.closed
-        mock_blob_downloader.close.assert_called_once()
+        mock_azstoragetorch_blob_client.close.assert_called_once()
 
-    def test_context_manager_closes_blob_io(self, blob_io, mock_blob_downloader):
+    def test_context_manager_closes_blob_io(
+        self, blob_io, mock_azstoragetorch_blob_client
+    ):
         assert not blob_io.closed
         with blob_io:
             pass
         assert blob_io.closed
-        mock_blob_downloader.close.assert_called_once()
+        mock_azstoragetorch_blob_client.close.assert_called_once()
 
-    def test_del_closes_blob_io(self, blob_io, mock_blob_downloader):
+    def test_del_closes_blob_io(self, blob_io, mock_azstoragetorch_blob_client):
         assert not blob_io.closed
         blob_io.__del__()
         assert blob_io.closed
-        mock_blob_downloader.close.assert_called_once()
+        mock_azstoragetorch_blob_client.close.assert_called_once()
 
     @pytest.mark.parametrize(
         "method,args",
@@ -192,19 +215,27 @@ class TestBlobIO:
         blob_io = BlobIO(blob_url, mode="rb")
         assert blob_io.readable()
 
-    def test_read(self, blob_io, blob_content, mock_blob_downloader):
+    def test_read(self, blob_io, blob_content, mock_azstoragetorch_blob_client):
         assert blob_io.read() == blob_content
         assert blob_io.tell() == len(blob_content)
-        mock_blob_downloader.download.assert_called_once_with(offset=0, length=None)
+        mock_azstoragetorch_blob_client.download.assert_called_once_with(
+            offset=0, length=None
+        )
 
-    def test_read_with_size(self, blob_io, blob_content, mock_blob_downloader):
-        mock_blob_downloader.download.return_value = blob_content[:1]
+    def test_read_with_size(
+        self, blob_io, blob_content, mock_azstoragetorch_blob_client
+    ):
+        mock_azstoragetorch_blob_client.download.return_value = blob_content[:1]
         assert blob_io.read(1) == blob_content[:1]
         assert blob_io.tell() == 1
-        mock_blob_downloader.download.assert_called_once_with(offset=0, length=1)
+        mock_azstoragetorch_blob_client.download.assert_called_once_with(
+            offset=0, length=1
+        )
 
-    def test_read_multiple_times(self, blob_io, blob_content, mock_blob_downloader):
-        mock_blob_downloader.download.side_effect = [
+    def test_read_multiple_times(
+        self, blob_io, blob_content, mock_azstoragetorch_blob_client
+    ):
+        mock_azstoragetorch_blob_client.download.side_effect = [
             blob_content[:1],
             blob_content[1:2],
             blob_content[2:],
@@ -212,38 +243,48 @@ class TestBlobIO:
         assert blob_io.read(1) == blob_content[:1]
         assert blob_io.read(1) == blob_content[1:2]
         assert blob_io.read() == blob_content[2:]
-        assert mock_blob_downloader.download.call_args_list == [
+        assert mock_azstoragetorch_blob_client.download.call_args_list == [
             mock.call(offset=0, length=1),
             mock.call(offset=1, length=1),
             mock.call(offset=2, length=None),
         ]
         assert blob_io.tell() == len(blob_content)
 
-    def test_read_after_seek(self, blob_io, blob_content, mock_blob_downloader):
+    def test_read_after_seek(
+        self, blob_io, blob_content, mock_azstoragetorch_blob_client
+    ):
         offset = 2
-        mock_blob_downloader.download.return_value = blob_content[offset:]
+        mock_azstoragetorch_blob_client.download.return_value = blob_content[offset:]
         assert blob_io.seek(offset) == offset
         assert blob_io.read() == blob_content[offset:]
         assert blob_io.tell() == len(blob_content)
-        mock_blob_downloader.download.assert_called_once_with(
+        mock_azstoragetorch_blob_client.download.assert_called_once_with(
             offset=offset, length=None
         )
 
-    def test_read_beyond_end(self, blob_io, blob_content, mock_blob_downloader):
+    def test_read_beyond_end(
+        self, blob_io, blob_content, mock_azstoragetorch_blob_client
+    ):
         assert blob_io.read() == blob_content
         assert blob_io.read() == b""
         assert blob_io.tell() == len(blob_content)
-        mock_blob_downloader.download.assert_called_once_with(offset=0, length=None)
+        mock_azstoragetorch_blob_client.download.assert_called_once_with(
+            offset=0, length=None
+        )
 
-    def test_read_size_zero(self, blob_io, mock_blob_downloader):
+    def test_read_size_zero(self, blob_io, mock_azstoragetorch_blob_client):
         assert blob_io.read(0) == b""
         assert blob_io.tell() == 0
-        mock_blob_downloader().download.assert_not_called()
+        mock_azstoragetorch_blob_client().download.assert_not_called()
 
     @pytest.mark.parametrize("size", [-1, None])
-    def test_read_size_synonyms_for_read_all(self, blob_io, mock_blob_downloader, size):
+    def test_read_size_synonyms_for_read_all(
+        self, blob_io, mock_azstoragetorch_blob_client, size
+    ):
         assert blob_io.read(size) == b"blob content"
-        mock_blob_downloader.download.assert_called_once_with(offset=0, length=None)
+        mock_azstoragetorch_blob_client.download.assert_called_once_with(
+            offset=0, length=None
+        )
 
     @pytest.mark.parametrize("size", [0.5, "1"])
     def test_read_raises_for_unsupported_size_types(self, blob_io, size):
@@ -283,7 +324,9 @@ class TestBlobIO:
         assert blob_io.seek(0) == 0
         assert blob_io.tell() == 0
 
-    def test_seek_beyond_end(self, blob_io, blob_length, mock_blob_downloader):
+    def test_seek_beyond_end(
+        self, blob_io, blob_length, mock_azstoragetorch_blob_client
+    ):
         # Note: Sort of quirky behavior that you can seek past the end of a
         # file and return a position that is larger than the size of the file.
         # However, this was chosen to be consistent in behavior with file-like
@@ -291,7 +334,7 @@ class TestBlobIO:
         assert blob_io.seek(blob_length + 1) == blob_length + 1
         assert blob_io.tell() == blob_length + 1
         assert blob_io.read(1) == b""
-        mock_blob_downloader.download.assert_not_called()
+        mock_azstoragetorch_blob_client.download.assert_not_called()
 
     def test_seek_cur(self, blob_io):
         assert blob_io.seek(1, os.SEEK_CUR) == 1


### PR DESCRIPTION
Implementation includes:
* Refactoring of BlobDownloader interface to azstoragetorch's own blob client class. This will be useful when we implement as we will not have separate classes for upload/download classes which makes it easier for dependency injection and keeping all Azure Blob specific logic to a single class.
* Relying on code generated clients for downloads. This was done to utilize a leaner download implementation for notable performance improvements over the public `download_blob()` method.

Note this pull request does not implement `readline()`. That will be done in a follow up PR.