### PR TITLE
Implement write for `BlobIO`

### DIFF
--- a/src/azstoragetorch/_client.py
+++ b/src/azstoragetorch/_client.py
@@ -9,9 +9,12 @@ import functools
 import io
 import logging
 import math
+import os
 import random
+import threading
 import time
-from typing import Optional, List, Tuple, Iterator, Union
+import uuid
+from typing import Optional, List, Tuple, Iterator, Union, Type
 
 from azure.core.credentials import (
     AzureSasCredential,
@@ -31,6 +34,12 @@ SDK_CREDENTIAL_TYPE = Optional[
         TokenCredential,
     ]
 ]
+SUPPORTED_WRITE_BYTES_LIKE_TYPE = Union[bytes, bytearray, memoryview]
+try:
+    STAGE_BLOCK_FUTURE_TYPE = concurrent.futures.Future[str]
+except TypeError:
+    # Python <3.9 does not support generic typing for futures
+    STAGE_BLOCK_FUTURE_TYPE = concurrent.futures.Future
 
 
 class AzStorageTorchBlobClient:
@@ -38,6 +47,7 @@ class AzStorageTorchBlobClient:
     _PARTITIONED_DOWNLOAD_THRESHOLD = 16 * 1024 * 1024
     _PARTITION_SIZE = 16 * 1024 * 1024
     _NUM_DOWNLOAD_ATTEMPTS = 3
+    _STAGE_BLOCK_SIZE = 32 * 1024 * 1024
     _RETRYABLE_READ_EXCEPTIONS = (
         azure.core.exceptions.IncompleteReadError,
         azure.core.exceptions.HttpResponseError,
@@ -48,12 +58,21 @@ class AzStorageTorchBlobClient:
         self,
         sdk_blob_client: azure.storage.blob.BlobClient,
         executor: Optional[concurrent.futures.Executor] = None,
+        max_in_flight_requests: Optional[int] = None,
     ):
         self._sdk_blob_client = sdk_blob_client
         self._generated_sdk_storage_client = self._sdk_blob_client._client
+        if max_in_flight_requests is None:
+            max_in_flight_requests = self._get_max_in_flight_requests()
         if executor is None:
-            executor = concurrent.futures.ThreadPoolExecutor()
+            executor = concurrent.futures.ThreadPoolExecutor(max_in_flight_requests)
         self._executor = executor
+        # The standard thread pool executor does not bound the number of tasks submitted to it.
+        # This semaphore introduces bound so that the number of submitted, in-progress
+        # futures are not greater than the available workers. This is important for cases where we
+        # buffer data into memory for uploads as is prevents large amounts of memory from being
+        # submitted to the executor when there are no workers available to upload it.
+        self._max_in_flight_semaphore = threading.Semaphore(max_in_flight_requests)
 
     @classmethod
     def from_blob_url(
@@ -76,8 +95,37 @@ class AzStorageTorchBlobClient:
         else:
             return self._partitioned_download(offset, length)
 
+    def stage_blocks(
+        self, data: SUPPORTED_WRITE_BYTES_LIKE_TYPE
+    ) -> List[STAGE_BLOCK_FUTURE_TYPE]:
+        if not data:
+            raise ValueError("Data must not be empty.")
+        stage_block_partitions = self._get_stage_block_partitions(data)
+        futures = []
+        for pos, length in stage_block_partitions:
+            self._max_in_flight_semaphore.acquire()
+            future = self._executor.submit(self._stage_block, data[pos : pos + length])
+            future.add_done_callback(self._release_in_flight_semaphore)
+            futures.append(future)
+        return futures
+
+    def commit_block_list(self, block_ids: List[str]) -> None:
+        blob_blocks = [azure.storage.blob.BlobBlock(block_id) for block_id in block_ids]
+        self._sdk_blob_client.commit_block_list(blob_blocks)
+
     def close(self) -> None:
         self._executor.shutdown()
+
+    def _get_max_in_flight_requests(self) -> int:
+        # Ideally we would just match this value to the max workers of the executor. However
+        # the executor class does not publicly expose its max worker count. So, instead we copy
+        # the max worker calculation from the executor class and inject it into both the executor
+        # and semaphore
+        #
+        # Note: Once we support Python 3.13, the default calculation for max workers for the executor
+        # uses os.process_cpu_count() instead. We should make sure to update the value here to match
+        # that as well for Python 3.13 environments.
+        return min(32, (os.cpu_count() or 1) + 4)
 
     @functools.cached_property
     def _blob_properties(self) -> azure.storage.blob.BlobProperties:
@@ -93,21 +141,25 @@ class AzStorageTorchBlobClient:
 
     def _partitioned_download(self, offset: int, length: int) -> bytes:
         futures = []
-        for partition in self._get_partitioned_reads(offset, length):
+        for read_partition in self._get_partitions(
+            offset, length, self._PARTITION_SIZE
+        ):
             futures.append(
-                self._executor.submit(self._download_with_retries, *partition)
+                self._executor.submit(self._download_with_retries, *read_partition)
             )
         return b"".join(f.result() for f in futures)
 
-    def _get_partitioned_reads(self, offset: int, length: int) -> List[Tuple[int, int]]:
+    def _get_partitions(
+        self, offset: int, length: int, partition_size: int
+    ) -> List[Tuple[int, int]]:
         end = offset + length
-        num_partitions = math.ceil(length / self._PARTITION_SIZE)
+        num_partitions = math.ceil(length / partition_size)
         partitions = []
         for i in range(num_partitions):
-            start = offset + i * self._PARTITION_SIZE
+            start = offset + i * partition_size
             if start >= end:
                 break
-            size = min(self._PARTITION_SIZE, end - start)
+            size = min(partition_size, end - start)
             partitions.append((start, size))
         return partitions
 
@@ -162,3 +214,16 @@ class AzStorageTorchBlobClient:
         for chunk in stream:
             content.write(chunk)
         return content.getvalue()
+
+    def _get_stage_block_partitions(
+        self, data: SUPPORTED_WRITE_BYTES_LIKE_TYPE
+    ) -> List[Tuple[int, int]]:
+        return self._get_partitions(0, len(data), self._STAGE_BLOCK_SIZE)
+
+    def _stage_block(self, data: SUPPORTED_WRITE_BYTES_LIKE_TYPE) -> str:
+        block_id = str(uuid.uuid4())
+        self._sdk_blob_client.stage_block(block_id, data)
+        return block_id
+
+    def _release_in_flight_semaphore(self, _: STAGE_BLOCK_FUTURE_TYPE) -> None:
+        self._max_in_flight_semaphore.release()

--- a/src/azstoragetorch/exceptions.py
+++ b/src/azstoragetorch/exceptions.py
@@ -1,0 +1,31 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+
+class AZStorageTorchError(Exception):
+    """Base class for exceptions raised by azstoragetorch."""
+
+    pass
+
+
+class FatalBlobIOWriteError(AZStorageTorchError):
+    """Raised when a fatal error occurs during BlobIO write operations.
+
+    When this exception is raised, it indicates no more writing can be performed
+    on the BlobIO object and no blocks staged as part of this BlobIO will be
+    committed. It is recommended to create a new BlobIO object and retry all
+    writes when attempting retries.
+    """
+
+    _MSG_FORMAT = (
+        "Fatal error occurred while writing data. No data written using this BlobIO instance "
+        "will be committed to blob. Encountered exception:\n{underlying_exception}"
+    )
+
+    def __init__(self, underlying_exception: BaseException):
+        super().__init__(
+            self._MSG_FORMAT.format(underlying_exception=underlying_exception)
+        )

--- a/src/azstoragetorch/io.py
+++ b/src/azstoragetorch/io.py
@@ -4,9 +4,10 @@
 # license information.
 # --------------------------------------------------------------------------
 
+import concurrent.futures
 import io
 import os
-from typing import get_args, Optional, Union, Literal, Type
+from typing import get_args, Optional, Union, Literal, Type, List
 import urllib.parse
 
 from azure.identity import DefaultAzureCredential
@@ -16,16 +17,22 @@ from azure.core.credentials import (
 )
 
 from azstoragetorch._client import SDK_CREDENTIAL_TYPE as _SDK_CREDENTIAL_TYPE
+from azstoragetorch._client import (
+    SUPPORTED_WRITE_BYTES_LIKE_TYPE as _SUPPORTED_WRITE_TYPES,
+)
+from azstoragetorch._client import STAGE_BLOCK_FUTURE_TYPE as _STAGE_BLOCK_FUTURE_TYPE
 from azstoragetorch._client import AzStorageTorchBlobClient as _AzStorageTorchBlobClient
+from azstoragetorch.exceptions import FatalBlobIOWriteError
 
 
-_SUPPORTED_MODES = Literal["rb"]
+_SUPPORTED_MODES = Literal["rb", "wb"]
 _AZSTORAGETORCH_CREDENTIAL_TYPE = Union[_SDK_CREDENTIAL_TYPE, Literal[False]]
 
 
 class BlobIO(io.IOBase):
     _READLINE_PREFETCH_SIZE = 4 * 1024 * 1024
     _READLINE_TERMINATOR = b"\n"
+    _WRITE_BUFFER_SIZE = 32 * 1024 * 1024
 
     def __init__(
         self,
@@ -51,10 +58,24 @@ class BlobIO(io.IOBase):
         # TODO: Consider using a bytearray and/or memoryview for readline buffer. There may be performance
         #  gains in regards to reducing the number of copies performed when consuming from buffer.
         self._readline_buffer = b""
+        self._write_buffer = bytearray()
+        self._all_stage_block_futures: List[_STAGE_BLOCK_FUTURE_TYPE] = []
+        self._in_progress_stage_block_futures: List[_STAGE_BLOCK_FUTURE_TYPE] = []
+        self._stage_block_exception: Optional[BaseException] = None
 
     def close(self) -> None:
-        self._close_client()
-        self._closed = True
+        if self.closed:
+            return
+        try:
+            # Any errors that occur while flushing or committing the block list are considered non-recoverable
+            # when using the BlobIO interface. So if an error occurs, we still close the BlobIO to further indicate
+            # that a new BlobIO instance will be needed and also avoid possibly calling the flush/commit logic again
+            # during garbage collection.
+            if self.writable():
+                self._commit_blob()
+        finally:
+            self._close_client()
+            self._closed = True
 
     @property
     def closed(self) -> bool:
@@ -65,17 +86,19 @@ class BlobIO(io.IOBase):
 
     def flush(self) -> None:
         self._validate_not_closed()
+        self._flush()
 
     def read(self, size: Optional[int] = -1, /) -> bytes:
         if size is not None:
             self._validate_is_integer("size", size)
             self._validate_min("size", size, -1)
+        self._validate_readable()
         self._validate_not_closed()
         self._invalidate_readline_buffer()
         return self._read(size)
 
     def readable(self) -> bool:
-        if self._mode == "rb":
+        if self._is_read_mode():
             self._validate_not_closed()
             return True
         return False
@@ -83,12 +106,14 @@ class BlobIO(io.IOBase):
     def readline(self, size: Optional[int] = -1, /) -> bytes:
         if size is not None:
             self._validate_is_integer("size", size)
+        self._validate_readable()
         self._validate_not_closed()
         return self._readline(size)
 
     def seek(self, offset: int, whence: int = os.SEEK_SET, /) -> int:
         self._validate_is_integer("offset", offset)
         self._validate_is_integer("whence", whence)
+        self._validate_seekable()
         self._validate_not_closed()
         self._invalidate_readline_buffer()
         return self._seek(offset, whence)
@@ -100,10 +125,16 @@ class BlobIO(io.IOBase):
         self._validate_not_closed()
         return self._position
 
-    def write(self, b: Union[bytes, bytearray], /) -> int:
-        raise NotImplementedError("write")
+    def write(self, b: _SUPPORTED_WRITE_TYPES, /) -> int:
+        self._validate_supported_write_type(b)
+        self._validate_writable()
+        self._validate_not_closed()
+        return self._write(b)
 
     def writable(self) -> bool:
+        if self._is_write_mode():
+            self._validate_not_closed()
+            return True
         return False
 
     def _validate_mode(self, mode: str) -> None:
@@ -119,6 +150,30 @@ class BlobIO(io.IOBase):
             raise ValueError(
                 f"{param_name} must be greater than or equal to {min_value}"
             )
+
+    def _validate_supported_write_type(self, b: _SUPPORTED_WRITE_TYPES) -> None:
+        if not isinstance(b, get_args(_SUPPORTED_WRITE_TYPES)):
+            raise TypeError(
+                f"Unsupported type for write: {type(b)}. Supported types: {get_args(_SUPPORTED_WRITE_TYPES)}"
+            )
+
+    def _validate_readable(self) -> None:
+        if not self._is_read_mode():
+            raise io.UnsupportedOperation("read")
+
+    def _validate_seekable(self) -> None:
+        if not self._is_read_mode():
+            raise io.UnsupportedOperation("seek")
+
+    def _validate_writable(self) -> None:
+        if not self._is_write_mode():
+            raise io.UnsupportedOperation("write")
+
+    def _is_read_mode(self) -> bool:
+        return self._mode == "rb"
+
+    def _is_write_mode(self) -> bool:
+        return self._mode == "wb"
 
     def _validate_not_closed(self) -> None:
         if self.closed:
@@ -229,9 +284,74 @@ class BlobIO(io.IOBase):
             return self._client.get_blob_size() + offset
         raise ValueError(f"Unsupported whence: {whence}")
 
+    def _flush(self) -> None:
+        self._check_for_stage_block_exceptions(wait=False)
+        self._flush_write_buffer()
+        self._check_for_stage_block_exceptions(wait=True)
+
+    def _flush_write_buffer(self) -> None:
+        if self._write_buffer:
+            futures = self._client.stage_blocks(memoryview(self._write_buffer))
+            self._all_stage_block_futures.extend(futures)
+            self._in_progress_stage_block_futures.extend(futures)
+            self._write_buffer = bytearray()
+
+    def _write(self, b: _SUPPORTED_WRITE_TYPES) -> int:
+        self._check_for_stage_block_exceptions(wait=False)
+        write_length = len(b)
+        self._write_buffer.extend(b)
+        if len(self._write_buffer) >= self._WRITE_BUFFER_SIZE:
+            self._flush_write_buffer()
+        self._position += write_length
+        return write_length
+
+    def _commit_blob(self) -> None:
+        self._flush()
+        block_ids = [f.result() for f in self._all_stage_block_futures]
+        self._raise_if_duplicate_block_ids(block_ids)
+        self._client.commit_block_list(block_ids)
+
+    def _raise_if_duplicate_block_ids(self, block_ids: str) -> None:
+        # An additional safety measure to ensure we never reuse block IDs within a BlobIO instance. This
+        # should not be an issue with UUID4 for block IDs, but that may not always be the case if
+        # block ID generation changes in the future.
+        if len(block_ids) != len(set(block_ids)):
+            raise RuntimeError(
+                "Unexpected duplicate block IDs detected. Not committing blob."
+            )
+
+    def _check_for_stage_block_exceptions(self, wait: bool = True) -> None:
+        # Before doing any additional processing, raise if an exception has already
+        # been processed especially if it is going to require us to wait for all
+        # in-progress futures to complete.
+        self._raise_if_fatal_write_error()
+        self._process_stage_block_futures_for_errors(wait)
+
+    def _process_stage_block_futures_for_errors(self, wait: bool) -> None:
+        if wait:
+            concurrent.futures.wait(
+                self._in_progress_stage_block_futures,
+                return_when=concurrent.futures.FIRST_EXCEPTION,
+            )
+        futures_still_in_progress = []
+        for future in self._in_progress_stage_block_futures:
+            if future.done():
+                if (
+                    self._stage_block_exception is None
+                    and future.exception() is not None
+                ):
+                    self._stage_block_exception = future.exception()
+            else:
+                futures_still_in_progress.append(future)
+        self._in_progress_stage_block_futures = futures_still_in_progress
+        self._raise_if_fatal_write_error()
+
+    def _raise_if_fatal_write_error(self) -> None:
+        if self._stage_block_exception is not None:
+            raise FatalBlobIOWriteError(self._stage_block_exception)
+
     def _close_client(self) -> None:
-        if not self._closed:
-            self._client.close()
+        self._client.close()
 
     def _is_at_end_of_blob(self) -> bool:
         return self._position >= self._client.get_blob_size()

--- a/src/azstoragetorch/io.py
+++ b/src/azstoragetorch/io.py
@@ -311,7 +311,7 @@ class BlobIO(io.IOBase):
         self._raise_if_duplicate_block_ids(block_ids)
         self._client.commit_block_list(block_ids)
 
-    def _raise_if_duplicate_block_ids(self, block_ids: str) -> None:
+    def _raise_if_duplicate_block_ids(self, block_ids: List[str]) -> None:
         # An additional safety measure to ensure we never reuse block IDs within a BlobIO instance. This
         # should not be an issue with UUID4 for block IDs, but that may not always be the case if
         # block ID generation changes in the future.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,5 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in the project root for
+# license information.
+# --------------------------------------------------------------------------

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -1,0 +1,11 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+import os
+
+
+def random_bytes(size):
+    return os.urandom(size)


### PR DESCRIPTION
When in write mode, the `BlobIO` has the following behavior:
* It is non-seekable
* Only supports uploading as block blobs
* Calls to `write()` are processed asynchronously; they immediately return and any errors are propagated in subsequent calls to `BlobIO` methods. This is an optimization to speed up `torch.save()` to avoid waiting for both the serialization of a model property and the actual staging of data.
* Small writes are cached in memory up to the stage block partition currently at 32 MiB
* Calls to `flush()` always stages any data cached in memory and waits for the stage block completion. This allows for synchronous processing of writes if needed.
* If any stage block operations result in an error, the error is considered fatal and any data that has been provided to the instance of `BlobIO` will not be committed. Any retrying of writes must be done using a new `BlobIO` instance.