### PR TITLE
Introduce `AzStorageBlobClientFactory`

### DIFF
--- a/src/azstoragetorch/io.py
+++ b/src/azstoragetorch/io.py
@@ -7,26 +7,13 @@
 import concurrent.futures
 import io
 import os
-from typing import get_args, Optional, Union, Literal, Type, List
-import urllib.parse
+from typing import get_args, Optional, Literal, List
 
-from azure.identity import DefaultAzureCredential
-from azure.core.credentials import (
-    AzureSasCredential,
-    TokenCredential,
-)
-
-from azstoragetorch._client import SDK_CREDENTIAL_TYPE as _SDK_CREDENTIAL_TYPE
-from azstoragetorch._client import (
-    SUPPORTED_WRITE_BYTES_LIKE_TYPE as _SUPPORTED_WRITE_TYPES,
-)
-from azstoragetorch._client import STAGE_BLOCK_FUTURE_TYPE as _STAGE_BLOCK_FUTURE_TYPE
-from azstoragetorch._client import AzStorageTorchBlobClient as _AzStorageTorchBlobClient
+from azstoragetorch import _client
 from azstoragetorch.exceptions import FatalBlobIOWriteError
 
 
 _SUPPORTED_MODES = Literal["rb", "wb"]
-_AZSTORAGETORCH_CREDENTIAL_TYPE = Union[_SDK_CREDENTIAL_TYPE, Literal[False]]
 
 
 class BlobIO(io.IOBase):
@@ -39,7 +26,7 @@ class BlobIO(io.IOBase):
         blob_url: str,
         mode: _SUPPORTED_MODES,
         *,
-        credential: _AZSTORAGETORCH_CREDENTIAL_TYPE = None,
+        credential: _client.AZSTORAGETORCH_CREDENTIAL_TYPE = None,
         **_internal_only_kwargs,
     ):
         self._blob_url = blob_url
@@ -48,9 +35,7 @@ class BlobIO(io.IOBase):
         self._client = self._get_azstoragetorch_blob_client(
             blob_url,
             credential,
-            _internal_only_kwargs.get(
-                "azstoragetorch_blob_client_cls", _AzStorageTorchBlobClient
-            ),
+            _internal_only_kwargs.get("_azstoragetorch_blob_client"),
         )
 
         self._position = 0
@@ -59,8 +44,10 @@ class BlobIO(io.IOBase):
         #  gains in regards to reducing the number of copies performed when consuming from buffer.
         self._readline_buffer = b""
         self._write_buffer = bytearray()
-        self._all_stage_block_futures: List[_STAGE_BLOCK_FUTURE_TYPE] = []
-        self._in_progress_stage_block_futures: List[_STAGE_BLOCK_FUTURE_TYPE] = []
+        self._all_stage_block_futures: List[_client.STAGE_BLOCK_FUTURE_TYPE] = []
+        self._in_progress_stage_block_futures: List[
+            _client.STAGE_BLOCK_FUTURE_TYPE
+        ] = []
         self._stage_block_exception: Optional[BaseException] = None
 
     def close(self) -> None:
@@ -125,7 +112,7 @@ class BlobIO(io.IOBase):
         self._validate_not_closed()
         return self._position
 
-    def write(self, b: _SUPPORTED_WRITE_TYPES, /) -> int:
+    def write(self, b: _client.SUPPORTED_WRITE_BYTES_LIKE_TYPE, /) -> int:
         self._validate_supported_write_type(b)
         self._validate_writable()
         self._validate_not_closed()
@@ -151,10 +138,12 @@ class BlobIO(io.IOBase):
                 f"{param_name} must be greater than or equal to {min_value}"
             )
 
-    def _validate_supported_write_type(self, b: _SUPPORTED_WRITE_TYPES) -> None:
-        if not isinstance(b, get_args(_SUPPORTED_WRITE_TYPES)):
+    def _validate_supported_write_type(
+        self, b: _client.SUPPORTED_WRITE_BYTES_LIKE_TYPE
+    ) -> None:
+        if not isinstance(b, get_args(_client.SUPPORTED_WRITE_BYTES_LIKE_TYPE)):
             raise TypeError(
-                f"Unsupported type for write: {type(b)}. Supported types: {get_args(_SUPPORTED_WRITE_TYPES)}"
+                f"Unsupported type for write: {type(b)}. Supported types: {get_args(_client.SUPPORTED_WRITE_BYTES_LIKE_TYPE)}"
             )
 
     def _validate_readable(self) -> None:
@@ -187,33 +176,13 @@ class BlobIO(io.IOBase):
     def _get_azstoragetorch_blob_client(
         self,
         blob_url: str,
-        credential: _AZSTORAGETORCH_CREDENTIAL_TYPE,
-        azstoragetorch_blob_client_cls: Type[_AzStorageTorchBlobClient],
-    ) -> _AzStorageTorchBlobClient:
-        return azstoragetorch_blob_client_cls.from_blob_url(
-            blob_url,
-            self._get_sdk_credential(blob_url, credential),
-        )
-
-    def _get_sdk_credential(
-        self, blob_url: str, credential: _AZSTORAGETORCH_CREDENTIAL_TYPE
-    ) -> _SDK_CREDENTIAL_TYPE:
-        if credential is False or self._blob_url_has_sas_token(blob_url):
-            return None
-        if credential is None:
-            return DefaultAzureCredential()
-        if isinstance(credential, (AzureSasCredential, TokenCredential)):
-            return credential
-        raise TypeError(f"Unsupported credential: {type(credential)}")
-
-    def _blob_url_has_sas_token(self, blob_url: str) -> bool:
-        parsed_url = urllib.parse.urlparse(blob_url)
-        if parsed_url.query is None:
-            return False
-        parsed_qs = urllib.parse.parse_qs(parsed_url.query)
-        # The signature is always required in a valid SAS token. So look for the "sig"
-        # key to determine if the URL has a SAS token.
-        return "sig" in parsed_qs
+        credential: _client.AZSTORAGETORCH_CREDENTIAL_TYPE,
+        azstoragetorch_blob_client: Optional[_client.AzStorageTorchBlobClient] = None,
+    ) -> _client.AzStorageTorchBlobClient:
+        if azstoragetorch_blob_client is not None:
+            return azstoragetorch_blob_client
+        client_factory = _client.AzStorageTorchBlobClientFactory(credential=credential)
+        return client_factory.get_blob_client_from_url(blob_url)
 
     def _readline(self, size: Optional[int]) -> bytes:
         consumed = b""
@@ -296,7 +265,7 @@ class BlobIO(io.IOBase):
             self._in_progress_stage_block_futures.extend(futures)
             self._write_buffer = bytearray()
 
-    def _write(self, b: _SUPPORTED_WRITE_TYPES) -> int:
+    def _write(self, b: _client.SUPPORTED_WRITE_BYTES_LIKE_TYPE) -> int:
         self._check_for_stage_block_exceptions(wait=False)
         write_length = len(b)
         self._write_buffer.extend(b)


### PR DESCRIPTION
The abstraction consolidates `AzStorageBlobClient` creation allowing:

1. Any SDK specific resolution (e.g., credential, default client configurations) to be consolidated to one class instead of being split between multiple classes
2. Enables better resource sharing across clients. **Note:** Currently, it just shares the transport and credential object. In later commits, we will explore sharing credential caching and/or pipelines

Both of these properties will be especially useful for dataset implementation as it will live in new classes and may create more than one client.

In addition, the commit updates the typing of the `io` module to access `_client` types as a property of the `_client` module. This made imports less verbose/easier to follow when trying to prevent non-public classes from leaking into io module which is public.