### PR TITLE
Add support for map-style datasets

### DIFF
--- a/src/azstoragetorch/_client.py
+++ b/src/azstoragetorch/_client.py
@@ -15,7 +15,7 @@ import threading
 import time
 import urllib.parse
 import uuid
-from typing import Optional, List, Tuple, Iterator, Union, Literal
+from typing import Optional, List, Tuple, Iterator, Union, Literal, TypedDict
 
 from azure.core.credentials import (
     AzureSasCredential,
@@ -44,6 +44,13 @@ SUPPORTED_WRITE_BYTES_LIKE_TYPE = Union[bytes, bytearray, memoryview]
 STAGE_BLOCK_FUTURE_TYPE = concurrent.futures.Future[str]
 
 
+class SDKKwargsType(TypedDict, total=False):
+    connection_data_block_size: int
+    transport: RequestsTransport
+    user_agent: str
+    credential: SDK_CREDENTIAL_TYPE
+
+
 class AzStorageTorchBlobClientFactory:
     # Socket timeouts set to match the default timeouts in Python SDK
     _SOCKET_CONNECTION_TIMEOUT = 20
@@ -60,6 +67,17 @@ class AzStorageTorchBlobClientFactory:
     def get_blob_client_from_url(self, blob_url: str) -> "AzStorageTorchBlobClient":
         blob_sdk_client = self._get_sdk_blob_client_from_url(blob_url)
         return AzStorageTorchBlobClient(blob_sdk_client)
+
+    def yield_blob_clients_from_container_url(
+        self, container_url: str, prefix: Optional[str] = None
+    ) -> Iterator["AzStorageTorchBlobClient"]:
+        container_sdk_client = self._get_sdk_container_client_from_container_url(
+            container_url
+        )
+        blob_names = container_sdk_client.list_blob_names(name_starts_with=prefix)
+        for blob_name in blob_names:
+            blob_client = container_sdk_client.get_blob_client(blob_name)
+            yield AzStorageTorchBlobClient(blob_client)
 
     def _get_sdk_credential(
         self, credential: AZSTORAGETORCH_CREDENTIAL_TYPE
@@ -78,23 +96,36 @@ class AzStorageTorchBlobClientFactory:
             read_timeout=self._SOCKET_READ_TIMEOUT,
         )
 
-    def _get_sdk_blob_client_from_url(self, blob_url: str) -> azure.storage.blob.BlobClient:
-        kwargs = {
+    def _get_sdk_blob_client_from_url(
+        self, blob_url: str
+    ) -> azure.storage.blob.BlobClient:
+        return azure.storage.blob.BlobClient.from_blob_url(
+            blob_url,
+            **self._get_sdk_client_kwargs(blob_url),
+        )
+
+    def _get_sdk_container_client_from_container_url(
+        self, container_url: str
+    ) -> azure.storage.blob.ContainerClient:
+        return azure.storage.blob.ContainerClient.from_container_url(
+            container_url,
+            **self._get_sdk_client_kwargs(container_url),
+        )
+
+    def _get_sdk_client_kwargs(self, resource_url: str) -> SDKKwargsType:
+        kwargs: SDKKwargsType = {
             "connection_data_block_size": self._CONNECTION_DATA_BLOCK_SIZE,
             "transport": self._transport,
             "user_agent": f"azstoragetorch/{__version__}",
         }
         credential = self._sdk_credential
-        if self._url_has_sas_token(blob_url):
+        if self._url_has_sas_token(resource_url):
             # The SDK prefers the explict credential over the one in the URL. So if a SAS token is
             # in the URL, we do not want the factory to automatically inject its credential, especially
             # if it would have been the default credential.
             credential = None
         kwargs["credential"] = credential
-        return azure.storage.blob.BlobClient.from_blob_url(
-            blob_url,
-            **kwargs,
-        )
+        return kwargs
 
     def _url_has_sas_token(self, resource_url: str) -> bool:
         parsed_url = urllib.parse.urlparse(resource_url)
@@ -116,6 +147,10 @@ class AzStorageTorchBlobClient:
         azure.core.exceptions.HttpResponseError,
         azure.core.exceptions.DecodeError,
     )
+    _QS_PARAMETERS_TO_INCLUDE = [
+        "snapshot",
+        "versionid",
+    ]
 
     def __init__(
         self,
@@ -128,15 +163,32 @@ class AzStorageTorchBlobClient:
 
         if max_in_flight_requests is None:
             max_in_flight_requests = self._get_max_in_flight_requests()
-        if executor is None:
-            executor = concurrent.futures.ThreadPoolExecutor(max_in_flight_requests)
+        self._max_in_flight_requests = max_in_flight_requests
         self._executor = executor
         # The standard thread pool executor does not bound the number of tasks submitted to it.
         # This semaphore introduces bound so that the number of submitted, in-progress
         # futures are not greater than the available workers. This is important for cases where we
         # buffer data into memory for uploads as is prevents large amounts of memory from being
         # submitted to the executor when there are no workers available to upload it.
-        self._max_in_flight_semaphore = threading.Semaphore(max_in_flight_requests)
+        self._max_in_flight_semaphore = threading.Semaphore(
+            self._max_in_flight_requests
+        )
+
+    @property
+    def url(self) -> str:
+        blob_sdk_url = self._sdk_blob_client.url
+        parsed_url = urllib.parse.urlparse(blob_sdk_url)
+        if parsed_url.query is None:
+            return blob_sdk_url
+        return self._get_url_with_filtered_query_string(parsed_url)
+
+    @property
+    def blob_name(self) -> str:
+        return self._sdk_blob_client.blob_name
+
+    @property
+    def container_name(self) -> str:
+        return self._sdk_blob_client.container_name
 
     def get_blob_size(self) -> int:
         return self._blob_properties.size
@@ -157,7 +209,9 @@ class AzStorageTorchBlobClient:
         futures = []
         for pos, length in stage_block_partitions:
             self._max_in_flight_semaphore.acquire()
-            future = self._executor.submit(self._stage_block, data[pos : pos + length])
+            future = self._get_executor().submit(
+                self._stage_block, data[pos : pos + length]
+            )
             future.add_done_callback(self._release_in_flight_semaphore)
             futures.append(future)
         return futures
@@ -167,7 +221,8 @@ class AzStorageTorchBlobClient:
         self._sdk_blob_client.commit_block_list(blob_blocks)
 
     def close(self) -> None:
-        self._executor.shutdown()
+        if self._executor is not None:
+            self._executor.shutdown()
 
     def _get_max_in_flight_requests(self) -> int:
         # Ideally we would just match this value to the max workers of the executor. However
@@ -181,6 +236,18 @@ class AzStorageTorchBlobClient:
         # if available, otherwise fall back to os.cpu_count().
         cpu_count_fn = getattr(os, "process_cpu_count", os.cpu_count)
         return min(32, (cpu_count_fn() or 1) + 4)
+
+    def _get_executor(self) -> concurrent.futures.Executor:
+        # We want executor creation to be lazy instead of instantiating immediately in
+        # the constructor because the executor itself is not pickleable. This is an issue
+        # when workers are used by PyTorch's DataLoader as workers are spawned as processes.
+        # So we delay executor creation until it is needed for reading/writing data which will
+        # happen after processes are spawned.
+        if self._executor is None:
+            self._executor = concurrent.futures.ThreadPoolExecutor(
+                self._max_in_flight_requests
+            )
+        return self._executor
 
     @functools.cached_property
     def _blob_properties(self) -> azure.storage.blob.BlobProperties:
@@ -200,7 +267,9 @@ class AzStorageTorchBlobClient:
             offset, length, self._PARTITION_SIZE
         ):
             futures.append(
-                self._executor.submit(self._download_with_retries, *read_partition)
+                self._get_executor().submit(
+                    self._download_with_retries, *read_partition
+                )
             )
         return b"".join(f.result() for f in futures)
 
@@ -282,3 +351,34 @@ class AzStorageTorchBlobClient:
 
     def _release_in_flight_semaphore(self, _: STAGE_BLOCK_FUTURE_TYPE) -> None:
         self._max_in_flight_semaphore.release()
+
+    def _get_url_with_filtered_query_string(
+        self, parsed_url: urllib.parse.ParseResult
+    ) -> str:
+        # Helper method to only include indentifying query string parameters for a blob URL. More specifically,
+        # we do not want to return any SAS tokens in the URL as it can accidentally result in leaking credentials
+        # as part of interfaces that expose the URL (e.g., azstoragetorch.datasets.Blob).
+        return urllib.parse.urlunparse(
+            (
+                parsed_url.scheme,
+                parsed_url.netloc,
+                parsed_url.path,
+                parsed_url.params,
+                self._filter_query_string(parsed_url.query),
+                parsed_url.fragment,
+            )
+        )
+
+    def _filter_query_string(self, qs: str) -> str:
+        # Ideally, we would be using urllib.parse to handle deconstructiong and reconstruction
+        # but the utilites also include quoting. This is an issue because parameters are often
+        # provided unquoted to the input URL (e.g., timestamps in URL use ":" instead of "%3A")
+        # and by avoiding quoting, we can better ensure the URL roundtripss correctly, matching
+        # the input URL.
+        qs_components = qs.split("&")
+        new_qs_components = []
+        for qs_component in qs_components:
+            for qs_parameter_to_include in self._QS_PARAMETERS_TO_INCLUDE:
+                if qs_component.startswith(f"{qs_parameter_to_include}="):
+                    new_qs_components.append(qs_component)
+        return "&".join(new_qs_components)

--- a/src/azstoragetorch/datasets.py
+++ b/src/azstoragetorch/datasets.py
@@ -1,0 +1,108 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+from collections.abc import Callable, Iterable
+from typing import Optional, Union, TypeVar, TypedDict
+
+import torch.utils.data
+
+from azstoragetorch.io import BlobIO
+from azstoragetorch import _client
+
+
+_TransformOutputType_co = TypeVar("_TransformOutputType_co", covariant=True)
+_TRANSFORM_TYPE = Callable[["Blob"], _TransformOutputType_co]
+
+
+class _DefaultTransformOutput(TypedDict):
+    url: str
+    data: bytes
+
+
+def _default_transform(blob: "Blob") -> _DefaultTransformOutput:
+    with blob.reader() as f:
+        content = f.read()
+    ret: _DefaultTransformOutput = {
+        "url": blob.url,
+        "data": content,
+    }
+    return ret
+
+
+class Blob:
+    def __init__(self, blob_client: _client.AzStorageTorchBlobClient):
+        self._blob_client = blob_client
+
+    @property
+    def url(self) -> str:
+        return self._blob_client.url
+
+    @property
+    def blob_name(self) -> str:
+        return self._blob_client.blob_name
+
+    @property
+    def container_name(self) -> str:
+        return self._blob_client.container_name
+
+    def reader(self) -> BlobIO:
+        return BlobIO(
+            self._blob_client.url, "rb", _azstoragetorch_blob_client=self._blob_client
+        )
+
+
+class BlobDataset(torch.utils.data.Dataset[_TransformOutputType_co]):
+    def __init__(
+        self, blobs: list[Blob], transform: _TRANSFORM_TYPE = _default_transform
+    ):
+        self._blobs = blobs
+        self._transform = transform
+
+    @classmethod
+    def from_blob_urls(
+        cls,
+        blob_urls: Union[str, Iterable[str]],
+        *,
+        credential: _client.AZSTORAGETORCH_CREDENTIAL_TYPE = None,
+        transform: _TRANSFORM_TYPE = _default_transform,
+    ) -> "BlobDataset":
+        if isinstance(blob_urls, str):
+            blob_urls = [blob_urls]
+        blob_client_factory = _client.AzStorageTorchBlobClientFactory(
+            credential=credential
+        )
+        blobs = [
+            Blob(blob_client_factory.get_blob_client_from_url(blob_url))
+            for blob_url in blob_urls
+        ]
+        return cls(blobs, transform=transform)
+
+    @classmethod
+    def from_container_url(
+        cls,
+        container_url: str,
+        *,
+        prefix: Optional[str] = None,
+        credential: _client.AZSTORAGETORCH_CREDENTIAL_TYPE = None,
+        transform: _TRANSFORM_TYPE = _default_transform,
+    ) -> "BlobDataset":
+        blob_client_factory = _client.AzStorageTorchBlobClientFactory(
+            credential=credential
+        )
+        blobs = [
+            Blob(blob_client)
+            for blob_client in blob_client_factory.yield_blob_clients_from_container_url(
+                container_url, prefix=prefix
+            )
+        ]
+        return cls(blobs, transform=transform)
+
+    def __getitem__(self, index: int) -> _TransformOutputType_co:
+        blob = self._blobs[index]
+        return self._transform(blob)
+
+    def __len__(self) -> int:
+        return len(self._blobs)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2,8 +2,23 @@ import pytest
 
 
 @pytest.fixture
-def blob_url():
-    return "https://myaccount.blob.core.windows.net/mycontainer/myblob"
+def container_name():
+    return "mycontainer"
+
+
+@pytest.fixture
+def container_url(container_name):
+    return f"https://myaccount.blob.core.windows.net/{container_name}"
+
+
+@pytest.fixture
+def blob_name():
+    return "myblob"
+
+
+@pytest.fixture
+def blob_url(container_url, blob_name):
+    return f"{container_url}/{blob_name}"
 
 
 @pytest.fixture

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -577,27 +577,15 @@ class TestAzStorageTorchBlobClient:
                 "https://account.blob.core.windows.net/container/blob",
                 "https://account.blob.core.windows.net/container/blob",
             ),
-            # URL with SAS token. SAS token should be removed.
+            # Cases to make sure query string is not included in returned URL.
             (
                 f"https://account.blob.core.windows.net/container/blob?{SAS_TOKEN}",
                 "https://account.blob.core.windows.net/container/blob",
             ),
-            # URL with snapshot. Snapshot should be kept
-            (
-                f"https://account.blob.core.windows.net/container/blob?snapshot={SNAPSHOT}",
-                f"https://account.blob.core.windows.net/container/blob?snapshot={SNAPSHOT}",
-            ),
-            # URL with version ID. Version ID should be kept
-            (
-                f"https://account.blob.core.windows.net/container/blob?versionid={VERSION_ID}",
-                f"https://account.blob.core.windows.net/container/blob?versionid={VERSION_ID}",
-            ),
-            # URL with snapshot, version ID, and SAS token. SAS token should be removed
             (
                 f"https://account.blob.core.windows.net/container/blob?snapshot={SNAPSHOT}&versionid={VERSION_ID}&{SAS_TOKEN}",
-                f"https://account.blob.core.windows.net/container/blob?snapshot={SNAPSHOT}&versionid={VERSION_ID}",
+                f"https://account.blob.core.windows.net/container/blob",
             ),
-            # URL with unknown query parameters. Unknown query parameters should be removed
             (
                 "https://account.blob.core.windows.net/container/blob?unknown1=val1&unknown2=val2",
                 "https://account.blob.core.windows.net/container/blob",

--- a/tests/unit/test_datasets.py
+++ b/tests/unit/test_datasets.py
@@ -1,0 +1,285 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in the project root for
+# license information.
+# --------------------------------------------------------------------------
+from unittest import mock
+import pytest
+
+from azure.core.credentials import AzureSasCredential
+
+from azstoragetorch.datasets import BlobDataset, Blob
+from azstoragetorch._client import (
+    AzStorageTorchBlobClient,
+    AzStorageTorchBlobClientFactory,
+)
+
+
+@pytest.fixture
+def create_mock_azstoragetorch_blob_client(blob_url, blob_content):
+    def _create_mock_azstoragetorch_blob_client(url=None, data=None):
+        if url is None:
+            url = blob_url
+        if data is None:
+            data = blob_content
+        client = mock.Mock(AzStorageTorchBlobClient)
+        client.url = url
+        client.get_blob_size.return_value = len(data)
+        client.download.return_value = data
+        return client
+
+    return _create_mock_azstoragetorch_blob_client
+
+
+@pytest.fixture
+def mock_azstoragetorch_blob_client(create_mock_azstoragetorch_blob_client):
+    return create_mock_azstoragetorch_blob_client()
+
+
+@pytest.fixture
+def blob(mock_azstoragetorch_blob_client):
+    return Blob(mock_azstoragetorch_blob_client)
+
+
+@pytest.fixture
+def mock_azstoragetorch_blob_client_factory():
+    return mock.Mock(AzStorageTorchBlobClientFactory)
+
+
+@pytest.fixture(autouse=True)
+def azstoragetorch_blob_factory_patch(mock_azstoragetorch_blob_client_factory):
+    with mock.patch(
+        "azstoragetorch._client.AzStorageTorchBlobClientFactory",
+        mock_azstoragetorch_blob_client_factory,
+    ):
+        mock_azstoragetorch_blob_client_factory.return_value = (
+            mock_azstoragetorch_blob_client_factory
+        )
+        yield mock_azstoragetorch_blob_client_factory
+
+
+@pytest.fixture
+def data_samples(container_url):
+    return [
+        {"url": f"{container_url}/blob{i}", "data": f"sample data {i}".encode("utf-8")}
+        for i in range(10)
+    ]
+
+
+@pytest.fixture
+def data_sample_blob_urls(data_samples):
+    return [sample["url"] for sample in data_samples]
+
+
+@pytest.fixture
+def data_sample_blob_clients(data_samples, create_mock_azstoragetorch_blob_client):
+    return [
+        create_mock_azstoragetorch_blob_client(**data_sample)
+        for data_sample in data_samples
+    ]
+
+
+class TestBlob:
+    def test_url(self, blob, mock_azstoragetorch_blob_client, blob_url):
+        mock_azstoragetorch_blob_client.url = blob_url
+        assert blob.url == blob_url
+
+    def test_blob_name(self, blob, mock_azstoragetorch_blob_client, blob_name):
+        mock_azstoragetorch_blob_client.blob_name = blob_name
+        assert blob.blob_name == blob_name
+
+    def test_container_name(
+        self, blob, mock_azstoragetorch_blob_client, container_name
+    ):
+        mock_azstoragetorch_blob_client.container_name = container_name
+        assert blob.container_name == container_name
+
+    def test_reader(self, blob, mock_azstoragetorch_blob_client):
+        with mock.patch(
+            "azstoragetorch.datasets.BlobIO", spec=True
+        ) as mock_blob_io_cls:
+            reader = blob.reader()
+            assert reader is mock_blob_io_cls.return_value
+            mock_blob_io_cls.assert_called_once_with(
+                blob.url,
+                "rb",
+                _azstoragetorch_blob_client=mock_azstoragetorch_blob_client,
+            )
+
+
+class TestBlobDataset:
+    def assert_expected_dataset(self, dataset, expected_data_samples):
+        assert isinstance(dataset, BlobDataset)
+        assert len(dataset) == len(expected_data_samples)
+        for i in range(len(dataset)):
+            assert dataset[i] == expected_data_samples[i]
+
+    def assert_factory_calls_from_container_url(
+        self,
+        mock_azstoragetorch_blob_client_factory,
+        expected_container_url,
+        expected_prefix=None,
+        expected_credential=None,
+    ):
+        mock_azstoragetorch_blob_client_factory.assert_called_once_with(
+            credential=expected_credential
+        )
+        mock_azstoragetorch_blob_client_factory.yield_blob_clients_from_container_url.assert_called_once_with(
+            expected_container_url, prefix=expected_prefix
+        )
+
+    def assert_factory_calls_from_blob_urls(
+        self,
+        mock_azstoragetorch_blob_client_factory,
+        expected_blob_urls,
+        expected_credential=None,
+    ):
+        mock_azstoragetorch_blob_client_factory.assert_called_once_with(
+            credential=expected_credential
+        )
+        assert (
+            mock_azstoragetorch_blob_client_factory.get_blob_client_from_url.call_args_list
+            == [mock.call(url) for url in expected_blob_urls]
+        )
+
+    def test_from_container_url(
+        self,
+        container_url,
+        mock_azstoragetorch_blob_client_factory,
+        data_samples,
+        data_sample_blob_clients,
+    ):
+        mock_azstoragetorch_blob_client_factory.yield_blob_clients_from_container_url.return_value = data_sample_blob_clients
+        dataset = BlobDataset.from_container_url(container_url)
+        self.assert_expected_dataset(dataset, expected_data_samples=data_samples)
+        self.assert_factory_calls_from_container_url(
+            mock_azstoragetorch_blob_client_factory,
+            expected_container_url=container_url,
+        )
+
+    def test_from_container_url_with_prefix(
+        self,
+        container_url,
+        mock_azstoragetorch_blob_client_factory,
+        data_samples,
+        data_sample_blob_clients,
+    ):
+        mock_azstoragetorch_blob_client_factory.yield_blob_clients_from_container_url.return_value = data_sample_blob_clients
+        dataset = BlobDataset.from_container_url(container_url, prefix="prefix/")
+        self.assert_expected_dataset(dataset, expected_data_samples=data_samples)
+        self.assert_factory_calls_from_container_url(
+            mock_azstoragetorch_blob_client_factory,
+            expected_container_url=container_url,
+            expected_prefix="prefix/",
+        )
+
+    def test_from_container_url_with_credential(
+        self,
+        container_url,
+        mock_azstoragetorch_blob_client_factory,
+        data_samples,
+        data_sample_blob_clients,
+    ):
+        credential = AzureSasCredential("sas_token")
+        mock_azstoragetorch_blob_client_factory.yield_blob_clients_from_container_url.return_value = data_sample_blob_clients
+        dataset = BlobDataset.from_container_url(container_url, credential=credential)
+        self.assert_expected_dataset(dataset, expected_data_samples=data_samples)
+        self.assert_factory_calls_from_container_url(
+            mock_azstoragetorch_blob_client_factory,
+            expected_container_url=container_url,
+            expected_credential=credential,
+        )
+
+    def test_from_container_url_with_transform(
+        self,
+        container_url,
+        mock_azstoragetorch_blob_client_factory,
+        data_sample_blob_urls,
+        data_sample_blob_clients,
+    ):
+        mock_azstoragetorch_blob_client_factory.yield_blob_clients_from_container_url.return_value = data_sample_blob_clients
+        dataset = BlobDataset.from_container_url(
+            container_url, transform=lambda x: x.url
+        )
+        self.assert_expected_dataset(
+            dataset, expected_data_samples=data_sample_blob_urls
+        )
+        self.assert_factory_calls_from_container_url(
+            mock_azstoragetorch_blob_client_factory,
+            expected_container_url=container_url,
+        )
+
+    def test_from_blob_urls(
+        self,
+        mock_azstoragetorch_blob_client_factory,
+        data_samples,
+        data_sample_blob_urls,
+        data_sample_blob_clients,
+    ):
+        mock_azstoragetorch_blob_client_factory.get_blob_client_from_url.side_effect = (
+            data_sample_blob_clients
+        )
+        dataset = BlobDataset.from_blob_urls(data_sample_blob_urls)
+        self.assert_expected_dataset(dataset, expected_data_samples=data_samples)
+        self.assert_factory_calls_from_blob_urls(
+            mock_azstoragetorch_blob_client_factory,
+            expected_blob_urls=data_sample_blob_urls,
+        )
+
+    def test_from_blob_urls_with_single_blob_url(
+        self,
+        mock_azstoragetorch_blob_client_factory,
+        data_samples,
+        data_sample_blob_urls,
+        data_sample_blob_clients,
+    ):
+        mock_azstoragetorch_blob_client_factory.get_blob_client_from_url.return_value = data_sample_blob_clients[
+            0
+        ]
+        dataset = BlobDataset.from_blob_urls(data_sample_blob_urls[0])
+        self.assert_expected_dataset(dataset, expected_data_samples=[data_samples[0]])
+        self.assert_factory_calls_from_blob_urls(
+            mock_azstoragetorch_blob_client_factory,
+            expected_blob_urls=[data_sample_blob_urls[0]],
+        )
+
+    def test_from_blob_urls_with_credential(
+        self,
+        mock_azstoragetorch_blob_client_factory,
+        data_samples,
+        data_sample_blob_urls,
+        data_sample_blob_clients,
+    ):
+        credential = AzureSasCredential("sas_token")
+        mock_azstoragetorch_blob_client_factory.get_blob_client_from_url.side_effect = (
+            data_sample_blob_clients
+        )
+        dataset = BlobDataset.from_blob_urls(
+            data_sample_blob_urls, credential=credential
+        )
+        self.assert_expected_dataset(dataset, expected_data_samples=data_samples)
+        self.assert_factory_calls_from_blob_urls(
+            mock_azstoragetorch_blob_client_factory,
+            expected_blob_urls=data_sample_blob_urls,
+            expected_credential=credential,
+        )
+
+    def test_from_blob_urls_with_transform(
+        self,
+        mock_azstoragetorch_blob_client_factory,
+        data_sample_blob_urls,
+        data_sample_blob_clients,
+    ):
+        mock_azstoragetorch_blob_client_factory.get_blob_client_from_url.side_effect = (
+            data_sample_blob_clients
+        )
+        dataset = BlobDataset.from_blob_urls(
+            data_sample_blob_urls, transform=lambda x: x.url
+        )
+        self.assert_expected_dataset(
+            dataset, expected_data_samples=data_sample_blob_urls
+        )
+        self.assert_factory_calls_from_blob_urls(
+            mock_azstoragetorch_blob_client_factory,
+            expected_blob_urls=data_sample_blob_urls,
+        )


### PR DESCRIPTION
It introduces the `datasets` module with its first dataset class, `BlobDataset`. It is a [map-style dataset](https://pytorch.org/docs/stable/data.html#map-style-datasets) intended for random sampling of dataset loaded into memory. The dataset class itself allows for accessing blobs listed from a container (e.g., `from_container_url`) or a customer provided list of blobs (e.g., `from_blob_urls`). In addition, customers can provide a custom transform that accepts a `Blob` object that can be used to access blob content and identifiers as part of the transform.

One additional refactor that needed to be made was to make executor instantiation in the blob client lazy. The executor itself is not pickleable when the PyTorch data loader uses workers. By making it lazy, it ensures that it is created once the process have been created and start reading data.

Note this PR does not include the following, which will be sent as subsequent PRs to help break up the review:
* [Iterable-style datasets](https://pytorch.org/docs/stable/data.html#iterable-style-datasets)
* End-to-end tests
* Docstrings for new public interfaces