### PR TITLE
Add API references for `BlobIO`

### DIFF
--- a/doc/sphinx/api.rst
+++ b/doc/sphinx/api.rst
@@ -1,0 +1,17 @@
+API Reference
+=============
+
+BlobIO
+------
+.. automodule:: azstoragetorch.io
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :exclude-members: fileno
+
+Exceptions
+----------
+.. automodule:: azstoragetorch.exceptions
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -23,3 +23,22 @@ language = 'Python'
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = 'furo'
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.intersphinx',
+    'sphinx_copybutton',
+]
+
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'torch': ('https://pytorch.org/docs/stable/', None),
+    # Matches the mapping the Azure Python SDKs use for cross-referencing with other SDKs.
+    # These URLs have objects.inv files that Sphinx can use to resolve auto-doc class references
+    # while the learn.microsoft.com version appear to not host this file.
+    'azure-core': ('https://azuresdkdocs.z19.web.core.windows.net/python/azure-core/latest/', None),
+    'azure-identity': ('https://azuresdkdocs.z19.web.core.windows.net/python/azure-identity/latest/', None),
+}
+
+autodoc_typehints = 'both'
+autodoc_typehints_description_target = 'documented_params'

--- a/doc/sphinx/index.rst
+++ b/doc/sphinx/index.rst
@@ -1,10 +1,11 @@
-Azure Storage for PyTorch documentation
+Azure Storage for PyTorch Documentation
 =======================================
 
 Azure Storage integrations for PyTorch.
 
-
+API Reference
+-------------
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
 
+   api

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
     "pytest",
     "sphinx",
     "furo",
+    "sphinx-copybutton",
 ]
 
 [project.urls]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -472,6 +472,7 @@ sphinx==7.4.7 ; python_full_version < '3.10' \
     #   azstoragetorch
     #   furo
     #   sphinx-basic-ng
+    #   sphinx-copybutton
 sphinx==8.1.3 ; python_full_version == '3.10.*' \
     --hash=sha256:09719015511837b76bf6e03e42eb7595ac8c2e41eeb9c29c5b755c6b677992a2 \
     --hash=sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927
@@ -479,6 +480,7 @@ sphinx==8.1.3 ; python_full_version == '3.10.*' \
     #   azstoragetorch
     #   furo
     #   sphinx-basic-ng
+    #   sphinx-copybutton
 sphinx==8.2.3 ; python_full_version >= '3.11' \
     --hash=sha256:398ad29dee7f63a75888314e9424d40f52ce5a6a87ae88e7071e80af296ec348 \
     --hash=sha256:4405915165f13521d875a8c29c8970800a0141c14cc5416a38feca4ea5d9b9c3
@@ -486,10 +488,15 @@ sphinx==8.2.3 ; python_full_version >= '3.11' \
     #   azstoragetorch
     #   furo
     #   sphinx-basic-ng
+    #   sphinx-copybutton
 sphinx-basic-ng==1.0.0b2 \
     --hash=sha256:9ec55a47c90c8c002b5960c57492ec3021f5193cb26cebc2dc4ea226848651c9 \
     --hash=sha256:eb09aedbabfb650607e9b4b68c9d240b90b1e1be221d6ad71d61c52e29f7932b
     # via furo
+sphinx-copybutton==0.5.2 \
+    --hash=sha256:4cf17c82fb9646d1bc9ca92ac280813a3b605d8c421225fd9913154103ee1fbd \
+    --hash=sha256:fb543fd386d917746c9a2c50360c7905b605726b9355cd26e9974857afeae06e
+    # via azstoragetorch
 sphinxcontrib-applehelp==2.0.0 \
     --hash=sha256:2f29ef331735ce958efa4734873f084941970894c6090408b079c61b2e1c06d1 \
     --hash=sha256:4cd3f0ec4ac5dd9c17ec65e9ab272c9b867ea77425228e68ecf08d6b28ddbdb5

--- a/src/azstoragetorch/exceptions.py
+++ b/src/azstoragetorch/exceptions.py
@@ -6,18 +6,18 @@
 
 
 class AZStorageTorchError(Exception):
-    """Base class for exceptions raised by azstoragetorch."""
+    """Base class for exceptions raised by ``azstoragetorch``."""
 
     pass
 
 
 class FatalBlobIOWriteError(AZStorageTorchError):
-    """Raised when a fatal error occurs during BlobIO write operations.
+    """Raised when a fatal error occurs during :py:class:`~azstoragetorch.io.BlobIO` write operations.
 
     When this exception is raised, it indicates no more writing can be performed
-    on the BlobIO object and no blocks staged as part of this BlobIO will be
-    committed. It is recommended to create a new BlobIO object and retry all
-    writes when attempting retries.
+    on the :py:class:`~azstoragetorch.io.BlobIO` object and no blocks staged as part of this
+    :py:class:`~azstoragetorch.io.BlobIO` will be committed. It is recommended to create a
+    new :py:class:`~azstoragetorch.io.BlobIO` object and retry all writes when attempting retries.
     """
 
     _MSG_FORMAT = (

--- a/uv.lock
+++ b/uv.lock
@@ -52,6 +52,7 @@ dev = [
     { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "sphinx-copybutton" },
 ]
 
 [package.metadata]
@@ -63,6 +64,7 @@ requires-dist = [
     { name = "furo", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "sphinx", marker = "extra == 'dev'" },
+    { name = "sphinx-copybutton", marker = "extra == 'dev'" },
     { name = "torch", specifier = ">=2.6.0,<3" },
 ]
 provides-extras = ["dev"]
@@ -973,6 +975,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/98/0b/a866924ded68efec7a1759587a4e478aec7559d8165fac8b2ad1c0e774d6/sphinx_basic_ng-1.0.0b2.tar.gz", hash = "sha256:9ec55a47c90c8c002b5960c57492ec3021f5193cb26cebc2dc4ea226848651c9", size = 20736 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3c/dd/018ce05c532a22007ac58d4f45232514cd9d6dd0ee1dc374e309db830983/sphinx_basic_ng-1.0.0b2-py3-none-any.whl", hash = "sha256:eb09aedbabfb650607e9b4b68c9d240b90b1e1be221d6ad71d61c52e29f7932b", size = 22496 },
+]
+
+[[package]]
+name = "sphinx-copybutton"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/2b/a964715e7f5295f77509e59309959f4125122d648f86b4fe7d70ca1d882c/sphinx-copybutton-0.5.2.tar.gz", hash = "sha256:4cf17c82fb9646d1bc9ca92ac280813a3b605d8c421225fd9913154103ee1fbd", size = 23039 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/48/1ea60e74949eecb12cdd6ac43987f9fd331156388dcc2319b45e2ebb81bf/sphinx_copybutton-0.5.2-py3-none-any.whl", hash = "sha256:fb543fd386d917746c9a2c50360c7905b605726b9355cd26e9974857afeae06e", size = 13343 },
 ]
 
 [[package]]


### PR DESCRIPTION
Work is built off of this previous PR: https://github.com/Azure/azure-storage-for-pytorch/pull/24. It leverages [Sphinx autodoc](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html) to generate HTML references from docstrings.

The commit also initializes the API reference page for the docs for future features that we want to leverage Sphinx autodoc for.