### PR TITLE
Implement iterable-style dataset

### DIFF
--- a/src/azstoragetorch/datasets.py
+++ b/src/azstoragetorch/datasets.py
@@ -4,7 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Iterator
 from typing import Optional, Union, TypeVar, TypedDict
 
 import torch.utils.data
@@ -56,9 +56,9 @@ class Blob:
 
 class BlobDataset(torch.utils.data.Dataset[_TransformOutputType_co]):
     def __init__(
-        self, blobs: list[Blob], transform: _TRANSFORM_TYPE = _default_transform
+        self, blobs: Iterable[Blob], transform: _TRANSFORM_TYPE = _default_transform
     ):
-        self._blobs = blobs
+        self._blobs = list(blobs)
         self._transform = transform
 
     @classmethod
@@ -69,15 +69,7 @@ class BlobDataset(torch.utils.data.Dataset[_TransformOutputType_co]):
         credential: _client.AZSTORAGETORCH_CREDENTIAL_TYPE = None,
         transform: _TRANSFORM_TYPE = _default_transform,
     ) -> "BlobDataset":
-        if isinstance(blob_urls, str):
-            blob_urls = [blob_urls]
-        blob_client_factory = _client.AzStorageTorchBlobClientFactory(
-            credential=credential
-        )
-        blobs = [
-            Blob(blob_client_factory.get_blob_client_from_url(blob_url))
-            for blob_url in blob_urls
-        ]
+        blobs = _BlobUrlsBlobIterable(blob_urls, credential=credential)
         return cls(blobs, transform=transform)
 
     @classmethod
@@ -89,15 +81,9 @@ class BlobDataset(torch.utils.data.Dataset[_TransformOutputType_co]):
         credential: _client.AZSTORAGETORCH_CREDENTIAL_TYPE = None,
         transform: _TRANSFORM_TYPE = _default_transform,
     ) -> "BlobDataset":
-        blob_client_factory = _client.AzStorageTorchBlobClientFactory(
-            credential=credential
+        blobs = _ContainerUrlBlobIterable(
+            container_url, prefix=prefix, credential=credential
         )
-        blobs = [
-            Blob(blob_client)
-            for blob_client in blob_client_factory.yield_blob_clients_from_container_url(
-                container_url, prefix=prefix
-            )
-        ]
         return cls(blobs, transform=transform)
 
     def __getitem__(self, index: int) -> _TransformOutputType_co:
@@ -106,3 +92,93 @@ class BlobDataset(torch.utils.data.Dataset[_TransformOutputType_co]):
 
     def __len__(self) -> int:
         return len(self._blobs)
+
+
+class IterableBlobDataset(torch.utils.data.IterableDataset[_TransformOutputType_co]):
+    def __init__(
+        self, blobs: Iterable[Blob], transform: _TRANSFORM_TYPE = _default_transform
+    ):
+        self._blobs = blobs
+        self._transform = transform
+
+    @classmethod
+    def from_blob_urls(
+        cls,
+        blob_urls: Union[str, Iterable[str]],
+        *,
+        credential: _client.AZSTORAGETORCH_CREDENTIAL_TYPE = None,
+        transform: _TRANSFORM_TYPE = _default_transform,
+    ) -> "IterableBlobDataset":
+        blobs = _BlobUrlsBlobIterable(blob_urls, credential=credential)
+        return cls(blobs, transform=transform)
+
+    @classmethod
+    def from_container_url(
+        cls,
+        container_url: str,
+        *,
+        prefix: Optional[str] = None,
+        credential: _client.AZSTORAGETORCH_CREDENTIAL_TYPE = None,
+        transform: _TRANSFORM_TYPE = _default_transform,
+    ) -> "IterableBlobDataset":
+        blobs = _ContainerUrlBlobIterable(
+            container_url, prefix=prefix, credential=credential
+        )
+        return cls(blobs, transform=transform)
+
+    def __iter__(self) -> Iterator[_TransformOutputType_co]:
+        worker_info = torch.utils.data.get_worker_info()
+        for i, blob in enumerate(self._blobs):
+            if self._should_yield_from_worker_shard(worker_info, i):
+                yield self._transform(blob)
+
+    def _should_yield_from_worker_shard(self, worker_info, blob_index: int) -> bool:
+        if worker_info is None:
+            return True
+        return blob_index % worker_info.num_workers == worker_info.id
+
+
+class _BaseBlobIterable(Iterable[Blob]):
+    def __init__(self, credential: _client.AZSTORAGETORCH_CREDENTIAL_TYPE = None):
+        self._credential = credential
+        self._blob_client_factory = _client.AzStorageTorchBlobClientFactory(
+            credential=self._credential
+        )
+
+    def __iter__(self) -> Iterator[Blob]:
+        raise NotImplementedError("__iter__")
+
+
+class _ContainerUrlBlobIterable(_BaseBlobIterable):
+    def __init__(
+        self,
+        container_url: str,
+        prefix: Optional[str] = None,
+        credential: _client.AZSTORAGETORCH_CREDENTIAL_TYPE = None,
+    ):
+        super().__init__(credential)
+        self._container_url = container_url
+        self._prefix = prefix
+
+    def __iter__(self) -> Iterator[Blob]:
+        blob_clients = self._blob_client_factory.yield_blob_clients_from_container_url(
+            self._container_url, prefix=self._prefix
+        )
+        for blob_client in blob_clients:
+            yield Blob(blob_client)
+
+
+class _BlobUrlsBlobIterable(_BaseBlobIterable):
+    def __init__(
+        self,
+        blob_urls: Union[str, Iterable[str]],
+        credential: _client.AZSTORAGETORCH_CREDENTIAL_TYPE = None,
+    ):
+        super().__init__(credential)
+        if isinstance(blob_urls, str):
+            blob_urls = [blob_urls]
+        self._blob_urls = blob_urls
+
+    def __iter__(self) -> Iterator[Blob]:
+        for blob_url in self._blob_urls:
+            yield Blob(self._blob_client_factory.get_blob_client_from_url(blob_url))

--- a/tests/unit/test_datasets.py
+++ b/tests/unit/test_datasets.py
@@ -8,7 +8,7 @@ import pytest
 
 from azure.core.credentials import AzureSasCredential
 
-from azstoragetorch.datasets import BlobDataset, Blob
+from azstoragetorch.datasets import BlobDataset, IterableBlobDataset, Blob
 from azstoragetorch._client import (
     AzStorageTorchBlobClient,
     AzStorageTorchBlobClientFactory,
@@ -283,3 +283,264 @@ class TestBlobDataset:
             mock_azstoragetorch_blob_client_factory,
             expected_blob_urls=data_sample_blob_urls,
         )
+
+
+class TestIterableBlobDataset:
+    def assert_expected_dataset_instantiation(
+        self, dataset, mock_azstoragetorch_blob_client_factory, expected_credential=None
+    ):
+        assert isinstance(dataset, IterableBlobDataset)
+        # An iterable dataset can instaniate a blob client factory but should not immediately be
+        # attempting to create blob clients. Those should be created in downstream calls to the
+        # instantiated dataset
+        mock_azstoragetorch_blob_client_factory.assert_called_once_with(
+            credential=expected_credential
+        )
+        assert not mock_azstoragetorch_blob_client_factory.yield_blob_clients_from_container_url.called
+        assert (
+            not mock_azstoragetorch_blob_client_factory.get_blob_client_from_url.called
+        )
+
+    def assert_expected_dataset(self, dataset, expected_data_samples):
+        assert isinstance(dataset, IterableBlobDataset)
+        assert list(dataset) == expected_data_samples
+
+    def assert_expected_dataset_from_blob_url(
+        self,
+        dataset,
+        mock_azstoragetorch_blob_client_factory,
+        expected_data_samples,
+        expected_blob_urls,
+    ):
+        assert isinstance(dataset, IterableBlobDataset)
+        for i, data_sample in enumerate(dataset):
+            # For from_blob_url, the dataset should be creating blob clients per sample iteration instead
+            # of all at once. Iterate through the dataset one at a time to confirm this behavior
+            assert data_sample == expected_data_samples[i]
+            assert (
+                mock_azstoragetorch_blob_client_factory.get_blob_client_from_url.call_args
+                == mock.call(expected_blob_urls[i])
+            )
+            assert (
+                mock_azstoragetorch_blob_client_factory.get_blob_client_from_url.call_count
+                == i + 1
+            )
+        assert (
+            mock_azstoragetorch_blob_client_factory.get_blob_client_from_url.call_count
+            == len(expected_data_samples)
+        )
+
+    def test_from_container_url(
+        self,
+        container_url,
+        mock_azstoragetorch_blob_client_factory,
+        data_samples,
+        data_sample_blob_clients,
+    ):
+        mock_azstoragetorch_blob_client_factory.yield_blob_clients_from_container_url.return_value = data_sample_blob_clients
+        dataset = IterableBlobDataset.from_container_url(container_url)
+        self.assert_expected_dataset_instantiation(
+            dataset, mock_azstoragetorch_blob_client_factory
+        )
+        self.assert_expected_dataset(dataset, expected_data_samples=data_samples)
+        mock_azstoragetorch_blob_client_factory.yield_blob_clients_from_container_url.assert_called_once_with(
+            container_url, prefix=None
+        )
+
+    def test_from_container_url_with_prefix(
+        self,
+        container_url,
+        mock_azstoragetorch_blob_client_factory,
+        data_samples,
+        data_sample_blob_clients,
+    ):
+        mock_azstoragetorch_blob_client_factory.yield_blob_clients_from_container_url.return_value = data_sample_blob_clients
+        dataset = IterableBlobDataset.from_container_url(
+            container_url, prefix="prefix/"
+        )
+        self.assert_expected_dataset_instantiation(
+            dataset, mock_azstoragetorch_blob_client_factory
+        )
+        self.assert_expected_dataset(dataset, expected_data_samples=data_samples)
+        mock_azstoragetorch_blob_client_factory.yield_blob_clients_from_container_url.assert_called_once_with(
+            container_url, prefix="prefix/"
+        )
+
+    def test_from_container_url_with_credential(
+        self,
+        container_url,
+        mock_azstoragetorch_blob_client_factory,
+        data_samples,
+        data_sample_blob_clients,
+    ):
+        credential = AzureSasCredential("sas_token")
+        mock_azstoragetorch_blob_client_factory.yield_blob_clients_from_container_url.return_value = data_sample_blob_clients
+        dataset = IterableBlobDataset.from_container_url(
+            container_url, credential=credential
+        )
+        self.assert_expected_dataset_instantiation(
+            dataset,
+            mock_azstoragetorch_blob_client_factory,
+            expected_credential=credential,
+        )
+        self.assert_expected_dataset(dataset, expected_data_samples=data_samples)
+        mock_azstoragetorch_blob_client_factory.yield_blob_clients_from_container_url.assert_called_once_with(
+            container_url, prefix=None
+        )
+
+    def test_from_container_url_with_transform(
+        self,
+        container_url,
+        mock_azstoragetorch_blob_client_factory,
+        data_sample_blob_urls,
+        data_sample_blob_clients,
+    ):
+        mock_azstoragetorch_blob_client_factory.yield_blob_clients_from_container_url.return_value = data_sample_blob_clients
+        dataset = IterableBlobDataset.from_container_url(
+            container_url, transform=lambda x: x.url
+        )
+        self.assert_expected_dataset_instantiation(
+            dataset, mock_azstoragetorch_blob_client_factory
+        )
+        self.assert_expected_dataset(
+            dataset, expected_data_samples=data_sample_blob_urls
+        )
+        mock_azstoragetorch_blob_client_factory.yield_blob_clients_from_container_url.assert_called_once_with(
+            container_url, prefix=None
+        )
+
+    def test_from_blob_urls(
+        self,
+        mock_azstoragetorch_blob_client_factory,
+        data_samples,
+        data_sample_blob_urls,
+        data_sample_blob_clients,
+    ):
+        mock_azstoragetorch_blob_client_factory.get_blob_client_from_url.side_effect = (
+            data_sample_blob_clients
+        )
+        dataset = IterableBlobDataset.from_blob_urls(data_sample_blob_urls)
+        self.assert_expected_dataset_instantiation(
+            dataset, mock_azstoragetorch_blob_client_factory
+        )
+        self.assert_expected_dataset_from_blob_url(
+            dataset,
+            mock_azstoragetorch_blob_client_factory,
+            expected_data_samples=data_samples,
+            expected_blob_urls=data_sample_blob_urls,
+        )
+
+    def test_from_blob_urls_with_single_blob_url(
+        self,
+        mock_azstoragetorch_blob_client_factory,
+        data_samples,
+        data_sample_blob_urls,
+        data_sample_blob_clients,
+    ):
+        mock_azstoragetorch_blob_client_factory.get_blob_client_from_url.return_value = data_sample_blob_clients[
+            0
+        ]
+        dataset = IterableBlobDataset.from_blob_urls(data_sample_blob_urls[0])
+        self.assert_expected_dataset_instantiation(
+            dataset, mock_azstoragetorch_blob_client_factory
+        )
+        self.assert_expected_dataset_from_blob_url(
+            dataset,
+            mock_azstoragetorch_blob_client_factory,
+            expected_data_samples=[data_samples[0]],
+            expected_blob_urls=[data_sample_blob_urls[0]],
+        )
+
+    def test_from_blob_urls_with_credential(
+        self,
+        mock_azstoragetorch_blob_client_factory,
+        data_samples,
+        data_sample_blob_urls,
+        data_sample_blob_clients,
+    ):
+        credential = AzureSasCredential("sas_token")
+        mock_azstoragetorch_blob_client_factory.get_blob_client_from_url.side_effect = (
+            data_sample_blob_clients
+        )
+        dataset = IterableBlobDataset.from_blob_urls(
+            data_sample_blob_urls, credential=credential
+        )
+        self.assert_expected_dataset_instantiation(
+            dataset,
+            mock_azstoragetorch_blob_client_factory,
+            expected_credential=credential,
+        )
+        self.assert_expected_dataset_from_blob_url(
+            dataset,
+            mock_azstoragetorch_blob_client_factory,
+            expected_data_samples=data_samples,
+            expected_blob_urls=data_sample_blob_urls,
+        )
+
+    def test_from_blob_urls_with_transform(
+        self,
+        mock_azstoragetorch_blob_client_factory,
+        data_sample_blob_urls,
+        data_sample_blob_clients,
+    ):
+        mock_azstoragetorch_blob_client_factory.get_blob_client_from_url.side_effect = (
+            data_sample_blob_clients
+        )
+        dataset = IterableBlobDataset.from_blob_urls(
+            data_sample_blob_urls, transform=lambda x: x.url
+        )
+        self.assert_expected_dataset_instantiation(
+            dataset,
+            mock_azstoragetorch_blob_client_factory,
+        )
+        self.assert_expected_dataset_from_blob_url(
+            dataset,
+            mock_azstoragetorch_blob_client_factory,
+            expected_data_samples=data_sample_blob_urls,
+            expected_blob_urls=data_sample_blob_urls,
+        )
+
+    @pytest.mark.parametrize(
+        "worker_info,expected_data_indices",
+        [
+            # No workers and one worker should return all data samples
+            (None, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+            (mock.Mock(id=0, num_workers=1), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+            # Two workers should return every other data sample
+            (mock.Mock(id=0, num_workers=2), [0, 2, 4, 6, 8]),
+            (mock.Mock(id=1, num_workers=2), [1, 3, 5, 7, 9]),
+            # Three workers should return every third data sample
+            (mock.Mock(id=0, num_workers=3), [0, 3, 6, 9]),
+            (mock.Mock(id=1, num_workers=3), [1, 4, 7]),
+            (mock.Mock(id=2, num_workers=3), [2, 5, 8]),
+            # A worker should only return a single data sample if the number of workers
+            # is greater than or equal to the number of data samples
+            (mock.Mock(id=0, num_workers=10), [0]),
+            (mock.Mock(id=9, num_workers=10), [9]),
+            (mock.Mock(id=7, num_workers=20), [7]),
+            # And if a worker is not in the range of data samples, it should return no data samples
+            (mock.Mock(id=10, num_workers=20), []),
+        ],
+    )
+    def test_worker_sharding(
+        self,
+        container_url,
+        mock_azstoragetorch_blob_client_factory,
+        data_samples,
+        data_sample_blob_clients,
+        worker_info,
+        expected_data_indices,
+    ):
+        mock_azstoragetorch_blob_client_factory.yield_blob_clients_from_container_url.return_value = data_sample_blob_clients
+        dataset = IterableBlobDataset.from_container_url(container_url)
+        self.assert_expected_dataset_instantiation(
+            dataset, mock_azstoragetorch_blob_client_factory
+        )
+        with mock.patch(
+            "torch.utils.data.get_worker_info", spec=True
+        ) as mock_get_worker_info:
+            mock_get_worker_info.return_value = worker_info
+            expected_data_samples = [data_samples[i] for i in expected_data_indices]
+            self.assert_expected_dataset(
+                dataset, expected_data_samples=expected_data_samples
+            )


### PR DESCRIPTION
Includes built-in support for worker sharding. Also refactored the datasets to share how blob client factories and blob objects are
returned by consolidating the logic into BlobIterables.

The PR also includes a commit to make semaphore creation of the blob client lazy. This logic was in a branch where I have e2e tests staged (and will be submitted as a later PR) but noticed it was not upstreamed to the final dataset implementation. So, I added it as part of this PR. Both datasets pass multiple-worker PyTorch DataLoader tests now. I also double checked there was nothing else missing from the e2e test branch; when the PR is submitted for e2e tests, it should be only test related changes.