### PR TITLE
Improve typing for datasets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     # range should be updated to match the new version.
     "azure-storage-blob>=12.24.0,<=12.24.1",
     "torch>=2.6.0,<3",
+    "typing-extensions>=4.13.2,<5",
 ]
 dynamic = ["version"]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -596,6 +596,7 @@ typing-extensions==4.13.2 \
     --hash=sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c \
     --hash=sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef
     # via
+    #   azstoragetorch
     #   azure-core
     #   azure-identity
     #   azure-storage-blob

--- a/src/azstoragetorch/datasets.py
+++ b/src/azstoragetorch/datasets.py
@@ -5,7 +5,8 @@
 # --------------------------------------------------------------------------
 
 from collections.abc import Callable, Iterable, Iterator
-from typing import Optional, Union, TypeVar, TypedDict
+from typing import Optional, Union, TypedDict
+from typing_extensions import Self, TypeVar
 
 import torch.utils.data
 
@@ -13,8 +14,9 @@ from azstoragetorch.io import BlobIO
 from azstoragetorch import _client
 
 
-_TransformOutputType_co = TypeVar("_TransformOutputType_co", covariant=True)
-_TRANSFORM_TYPE = Callable[["Blob"], _TransformOutputType_co]
+_TransformOutputType_co = TypeVar(
+    "_TransformOutputType_co", covariant=True, default="_DefaultTransformOutput"
+)
 
 
 class _DefaultTransformOutput(TypedDict):
@@ -56,9 +58,13 @@ class Blob:
 
 class BlobDataset(torch.utils.data.Dataset[_TransformOutputType_co]):
     def __init__(
-        self, blobs: Iterable[Blob], transform: _TRANSFORM_TYPE = _default_transform
+        self,
+        blobs: Iterable[Blob],
+        transform: Optional[Callable[[Blob], _TransformOutputType_co]] = None,
     ):
         self._blobs = list(blobs)
+        if transform is None:
+            transform = _default_transform
         self._transform = transform
 
     @classmethod
@@ -67,8 +73,8 @@ class BlobDataset(torch.utils.data.Dataset[_TransformOutputType_co]):
         blob_urls: Union[str, Iterable[str]],
         *,
         credential: _client.AZSTORAGETORCH_CREDENTIAL_TYPE = None,
-        transform: _TRANSFORM_TYPE = _default_transform,
-    ) -> "BlobDataset":
+        transform: Optional[Callable[[Blob], _TransformOutputType_co]] = None,
+    ) -> Self:
         blobs = _BlobUrlsBlobIterable(blob_urls, credential=credential)
         return cls(blobs, transform=transform)
 
@@ -79,8 +85,8 @@ class BlobDataset(torch.utils.data.Dataset[_TransformOutputType_co]):
         *,
         prefix: Optional[str] = None,
         credential: _client.AZSTORAGETORCH_CREDENTIAL_TYPE = None,
-        transform: _TRANSFORM_TYPE = _default_transform,
-    ) -> "BlobDataset":
+        transform: Optional[Callable[[Blob], _TransformOutputType_co]] = None,
+    ) -> Self:
         blobs = _ContainerUrlBlobIterable(
             container_url, prefix=prefix, credential=credential
         )
@@ -96,9 +102,13 @@ class BlobDataset(torch.utils.data.Dataset[_TransformOutputType_co]):
 
 class IterableBlobDataset(torch.utils.data.IterableDataset[_TransformOutputType_co]):
     def __init__(
-        self, blobs: Iterable[Blob], transform: _TRANSFORM_TYPE = _default_transform
+        self,
+        blobs: Iterable[Blob],
+        transform: Optional[Callable[[Blob], _TransformOutputType_co]] = None,
     ):
         self._blobs = blobs
+        if transform is None:
+            transform = _default_transform
         self._transform = transform
 
     @classmethod
@@ -107,8 +117,8 @@ class IterableBlobDataset(torch.utils.data.IterableDataset[_TransformOutputType_
         blob_urls: Union[str, Iterable[str]],
         *,
         credential: _client.AZSTORAGETORCH_CREDENTIAL_TYPE = None,
-        transform: _TRANSFORM_TYPE = _default_transform,
-    ) -> "IterableBlobDataset":
+        transform: Optional[Callable[[Blob], _TransformOutputType_co]] = None,
+    ) -> Self:
         blobs = _BlobUrlsBlobIterable(blob_urls, credential=credential)
         return cls(blobs, transform=transform)
 
@@ -119,8 +129,8 @@ class IterableBlobDataset(torch.utils.data.IterableDataset[_TransformOutputType_
         *,
         prefix: Optional[str] = None,
         credential: _client.AZSTORAGETORCH_CREDENTIAL_TYPE = None,
-        transform: _TRANSFORM_TYPE = _default_transform,
-    ) -> "IterableBlobDataset":
+        transform: Optional[Callable[[Blob], _TransformOutputType_co]] = None,
+    ) -> Self:
         blobs = _ContainerUrlBlobIterable(
             container_url, prefix=prefix, credential=credential
         )

--- a/uv.lock
+++ b/uv.lock
@@ -41,6 +41,7 @@ dependencies = [
     { name = "azure-identity" },
     { name = "azure-storage-blob" },
     { name = "torch" },
+    { name = "typing-extensions" },
 ]
 
 [package.optional-dependencies]
@@ -66,6 +67,7 @@ requires-dist = [
     { name = "sphinx", marker = "extra == 'dev'" },
     { name = "sphinx-copybutton", marker = "extra == 'dev'" },
     { name = "torch", specifier = ">=2.6.0,<3" },
+    { name = "typing-extensions", specifier = ">=4.13.2,<5" },
 ]
 provides-extras = ["dev"]
 


### PR DESCRIPTION
Transform type is now properly plumbed through so based on the transform that is used the correct type is propagated. This was done by:

1. Introducing a `default` of the default typed dict to our transform type var
2. Use `Self` for the return type to ensure we include the generic as part of the type
3. Move the default transform out of the signature and instead use `None` so `mypy` would not always assume a string was the generic
4. Stop using a shared `Callable` alias and instead expand the callable expression for each `transform` argument. I was finding `mypy` would resolve the shared callable to the default type and apply that resolution to all uses of it.

This also required adding `typing-extensions`. The library already indirectly depends on `typing-extensions` so it is not a net new dependency.

To test that it is working as expected, I wrote a script with purposeful wrong type usage to make sure mypy properly flagged incorrect usage and did not flag correct usage:
```python
from azstoragetorch.datasets import BlobDataset, Blob

BLOB_URL = "https://<account>.blob.core.windows.net/<container>/<blob>"

dataset = BlobDataset.from_blob_urls(BLOB_URL)

# These should pass mypy for default transform
dataset[0]["url"]
dataset[0]["data"]

# These should run into mypy issues
dataset[0].url  # Dicts do not have url method
dataset[0]["not-a-key"]  # Access a key that does not exist


def to_url(blob: Blob) -> str:
    return blob.url


dataset_with_transform = BlobDataset.from_blob_urls(BLOB_URL, transform=to_url)

# Type should be str so we should be able to do things like concat strings
dataset_with_transform[0] + "add string together"

# These should run into mypy issues
dataset_with_transform[0]["url"]  # Complain about slicing with a string
dataset_with_transform[0]["data"]
dataset_with_transform[0].not_a_method()  # String does not have this method


# This will fail because transform does not match specified type of int
dataset_with_wrong_transform: BlobDataset[int] = BlobDataset.from_blob_urls(
    BLOB_URL, transform=to_url
)
```
Running `mpy` on it results in the expected errors:
```
> mypy .\check-dataset-type.py
check-dataset-type.py:12: error: "_DefaultTransformOutput" has no attribute "url"  [attr-defined]
check-dataset-type.py:13: error: TypedDict "_DefaultTransformOutput" has no key "not-a-key"  [typeddict-item]
check-dataset-type.py:26: error: Invalid index type "str" for "str"; expected type "SupportsIndex | slice[Any, Any, Any]"  [index]
check-dataset-type.py:27: error: Invalid index type "str" for "str"; expected type "SupportsIndex | slice[Any, Any, Any]"  [index]
check-dataset-type.py:28: error: "str" has no attribute "not_a_method"  [attr-defined]
check-dataset-type.py:33: error: Argument "transform" to "from_blob_urls" of "BlobDataset" has incompatible type "Callable[[Blob], str]"; expected "Callable[[Blob], int] | None"  [arg-type]
Found 6 errors in 1 file (checked 1 source file)
```