### PR TITLE
Plumb connection data block size to transport

### DIFF
--- a/src/azstoragetorch/_client.py
+++ b/src/azstoragetorch/_client.py
@@ -97,6 +97,7 @@ class AzStorageTorchBlobClientFactory:
         return RequestsTransport(
             connection_timeout=self._SOCKET_CONNECTION_TIMEOUT,
             read_timeout=self._SOCKET_READ_TIMEOUT,
+            connection_data_block_size=self._CONNECTION_DATA_BLOCK_SIZE,
         )
 
     def _get_sdk_blob_client_from_url(
@@ -121,7 +122,6 @@ class AzStorageTorchBlobClientFactory:
 
     def _get_sdk_client_kwargs(self, resource_url: str) -> SDKKwargsType:
         kwargs: SDKKwargsType = {
-            "connection_data_block_size": self._CONNECTION_DATA_BLOCK_SIZE,
             "transport": self._transport,
             "user_agent": f"azstoragetorch/{__version__}",
         }

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -300,7 +300,6 @@ class TestAzStorageTorchBlobClientFactory:
         expected_from_url_kwargs = {
             "credential": expected_credential,
             "transport": expected_transport,
-            "connection_data_block_size": 256 * 1024,
             "user_agent": f"azstoragetorch/{__version__}",
         }
         if expected_pipeline is not None:
@@ -449,7 +448,9 @@ class TestAzStorageTorchBlobClientFactory:
                 expected_transport=mock_requests_transport_cls.return_value,
             )
             mock_requests_transport_cls.assert_called_once_with(
-                connection_timeout=20, read_timeout=60
+                connection_timeout=20,
+                read_timeout=60,
+                connection_data_block_size=256 * 1024,
             )
 
     def test_reuses_transport(self, blob_url, mock_sdk_blob_client):


### PR DESCRIPTION
Previously, this had been provided to the client's constructor. However, because we are now creating the transport ourselves and sharing it as part of the factory, the configuration is no longer used when provided to the client since we are providing an explicit transport. Instead, we need to provide it to the transport we create.

I also confirmed that we are not missing any other configuration that the SDK client sets for us in the transport by printing out the `kwargs` provided to `RequestsTransport` and running this script:
```python
from azstoragetorch.io import BlobIO
from azure.storage.blob import BlobClient

BLOB_URL = "https://azstoragetorchdev.blob.core.windows.net/models/model.pth"

BlobIO(BLOB_URL, mode="rb", credential=False)
BlobClient.from_blob_url(BLOB_URL, connection_data_block_size=256*1024)
```
The output from this was:
```
Kwargs to request transport {'connection_timeout': 20, 'read_timeout': 60, 'connection_data_block_size': 262144}
Kwargs to request transport {'sdk_moniker': 'storage-blob/12.24.1', 'connection_data_block_size': 262144, 'connection_timeout': 20, 'read_timeout': 60}
```
Which the only difference was `sdk_moniker` which is not used by `RequestTransport`. I also looked through [`RequestTransport`](https://github.com/Azure/azure-sdk-for-python/blob/066b3035a22e65d0ef6ebbb4d742cff8ee871818/sdk/core/azure-core/azure/core/pipeline/transport/_requests_basic.py#L227) and [`ConnectionConfiguration`](https://github.com/Azure/azure-sdk-for-python/blob/066b3035a22e65d0ef6ebbb4d742cff8ee871818/sdk/core/azure-core/azure/core/configuration.py#L109) to confirm there were no other settings based on their configurable properties and keyword arguments that `azstoragetorch` used that we need to account for.