### PR TITLE
Do not share transports from container clients

### DIFF
--- a/src/azstoragetorch/exceptions.py
+++ b/src/azstoragetorch/exceptions.py
@@ -29,3 +29,35 @@ class FatalBlobIOWriteError(AZStorageTorchError):
         super().__init__(
             self._MSG_FORMAT.format(underlying_exception=underlying_exception)
         )
+
+
+class ClientRequestIdMismatchError(AZStorageTorchError):
+    """Raised when a client request ID in a response does not match the ID in it's originating request.
+
+    If receiving this error as part of using both an azstoragetorch dataset and a
+    PyTorch DataLoader, it may be because the dataset is being accessed in both the
+    main process and a DataLoader's worker process. This can cause unintentional
+    sharing of resources. To fix this error, consider not accessing the dataset's
+    samples in the main process or not using workers with the DataLoader.
+    """
+
+    _MSG_FORMAT = (
+        "Client request ID: {request_client_id} does not match echoed client request ID: "
+        "{response_client_id}.  Service request ID: {service_request_id}. "
+        "If receiving this error as part of using both an azstoragetorch dataset and a "
+        "PyTorch DataLoader, it may be because the dataset is being accessed in both the "
+        "main process and a DataLoader's worker process. This can cause unintentional "
+        "sharing of resources. To fix this error, consider not accessing the dataset's "
+        "samples in the main process or not using workers with the DataLoader."
+    )
+
+    def __init__(
+        self, request_client_id: str, response_client_id: str, service_request_id: str
+    ):
+        super().__init__(
+            self._MSG_FORMAT.format(
+                request_client_id=request_client_id,
+                response_client_id=response_client_id,
+                service_request_id=service_request_id,
+            )
+        )

--- a/tests/e2e/test_datasets.py
+++ b/tests/e2e/test_datasets.py
@@ -324,14 +324,18 @@ class TestDatasets:
             assert loaded_samples == dataset_case.expected_data_samples
 
     @pytest.mark.parametrize("dataset_cls", [BlobDataset, IterableBlobDataset])
-    def test_loader_with_workers(
+    def test_loader_with_workers_and_epochs(
         self, dataset_cls, create_dataset_case, all_case_kwargs
     ):
         dataset_case = create_dataset_case(dataset_cls, **all_case_kwargs)
         dataset = dataset_case.to_dataset()
         loader = torch.utils.data.DataLoader(dataset, batch_size=None, num_workers=4)
-        loaded_samples = list(loader)
-        assert loaded_samples == dataset_case.expected_data_samples
+        # Include multiple epochs to ensure the dataset is compatible when multiple
+        # processes are used as well as across dataloader iterations, which will
+        # create new workers/processes for each iteration.
+        for _ in range(2):
+            loaded_samples = list(loader)
+            assert loaded_samples == dataset_case.expected_data_samples
 
     @pytest.mark.parametrize("dataset_cls", [BlobDataset, IterableBlobDataset])
     def test_loader_with_batch_size(


### PR DESCRIPTION
It addresses an issue with `BlobDataset.from_container_url()` datasets and multi-worker PyTorch dataloaders where underlying `requests` transport is not safe when used prior to process forking; it can result in child processes sharing connections.

By not using a new transport and not reusing that transport as part of blob clients, it better ensures no API calls are made on `requests` sessions that are intended to be shared after a fork occurs. This is because the List Blob API calls will happen as part of the parent process for a map-style dataset, during instantiation and any blob clients, that all share a transport, should only be used to make API calls in data loader worker processes.

An echo client request ID policy was added to ensure that requests made by the client match responses returned. This is an extra guard rail to ensure when using an azstoragetorch interface with processes, customers will not successfully process a response from a different request because the underlying connection resource was shared as part of forking.

It also updates e2e multi-worker dataloader case to include multiple epochs to make sure a multi-worker dataloader can be used across multiple epochs as well.