### PR TITLE
Add intro to `azstoragetorch` Jupyter notebook

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@
 Makefile text eol=lf
 requirements-dev.txt text eol=lf
 uv.lock text eol=lf
+samples/intro_notebook/azstoragetorch-intro.ipynb eol=lf

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,6 @@ include requirements-dev.txt
 recursive-include tests *.py
 recursive-include doc *
 include mypy.ini
-recursive-include samples *.py
+recursive-include samples *
 
 exclude uv.lock

--- a/README.md
+++ b/README.md
@@ -139,6 +139,20 @@ for batch in dataloader:
 ```
 
 
+## Additional resources
+
+For more information on using the Azure Storage Connector for PyTorch, see the following resources:
+
+* [Official documentation][official documentation]
+* [Code samples](samples/)
+* [Microsoft Build 2025 presentation][2025 build presentation] - Watch this presentation on the Azure Storage
+Connector for PyTorch to learn more about the library and how to use its features with PyTorch.
+* [Introductory Jupyter notebook](samples/intro_notebook/azstoragetorch-intro.ipynb) - Run this notebook to learn
+how to use the library to save and load PyTorch models and datasets from Azure Blob Storage. This is the same notebook
+used in the [Microsoft Build 2025 presentation][2025 build presentation].
+
+
+
 ## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
@@ -180,3 +194,5 @@ or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any addi
 [blobio reference]: https://azure.github.io/azure-storage-for-pytorch/api.html#azstoragetorch.io.BlobIO
 [blobdataset reference]: https://azure.github.io/azure-storage-for-pytorch/api.html#azstoragetorch.datasets.BlobDataset
 [iterableblobdataset reference]: https://azure.github.io/azure-storage-for-pytorch/api.html#azstoragetorch.datasets.IterableBlobDataset
+
+[2025 build presentation]: https://youtu.be/lJ9ZiiVP1-w?si=zowVmXemFK4w9HKc&t=1437

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,3 +59,6 @@ package-dir = {"" = "src"}
 
 [tool.setuptools.dynamic]
 version = {attr = "azstoragetorch._version.__version__"}
+
+[tool.ruff]
+extend-exclude = ["*.ipynb"]

--- a/samples/intro_notebook/azstoragetorch-intro.ipynb
+++ b/samples/intro_notebook/azstoragetorch-intro.ipynb
@@ -1,0 +1,520 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "448d129b-d0be-4141-a6f9-63382273b1cf",
+   "metadata": {},
+   "source": [
+    "# Installation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9354340b-71ff-403c-b77b-1962c64a93b7",
+   "metadata": {},
+   "source": [
+    "To use the Azure Storage Connector for PyTorch, we can install it with `pip`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "62269474-4e2e-48c3-8f4b-a1862546127c",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "%pip install azstoragetorch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1a48f98e-a52c-43f6-b93c-14925f22b492",
+   "metadata": {},
+   "source": [
+    "\n",
+    "\n",
+    "And we can confirm `azstoragetorch` is installed by importing it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "968729ec-d21e-40ce-8236-e5c614cdb030",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import azstoragetorch\n",
+    "print(azstoragetorch)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "645adda4-c0b3-447d-b753-02792f27f6d8",
+   "metadata": {},
+   "source": [
+    "Let's also install some other packages we'll need for later demos:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aad39d1e-3688-4f45-80b3-c29b2fe196d7",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "%pip install Pillow torchvision"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1a9de99-1ce5-45e2-8475-b6fe517d768e",
+   "metadata": {},
+   "source": [
+    "# Bootstrap"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c6f196b-df9f-487d-9d1c-e1a4f7dadb51",
+   "metadata": {},
+   "source": [
+    "Prior to running through the steps in this notebook, run the cell below to bootstrap resources needed for running this notebook. Make sure to replace `<replace-account-name>` with the Azure Storage account name you want to use for this notebook.\n",
+    "\n",
+    "In running the `bootstrap.py` script, it will:\n",
+    "* Create a container named `azstoragetorchintro`\n",
+    "* Create a local directory `local-models` with a ResNet-18 model\n",
+    "* Upload the ResNet-18 model to the `azstoragetorchintro` container\n",
+    "* Upload the Caltech 101 dataset to the `azstoragetorchintro` container"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a66ad024-1841-43db-a84b-3148aba0999d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%run bootstrap.py \"https://<replace-account-name>.blob.core.windows.net\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "05b88d3f-95de-4afc-aaf5-bf011a4229d1",
+   "metadata": {},
+   "source": [
+    "Copy the `CONTAINER_URL` output value from previous cell to `CONTAINER_URL` value in cell below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c436070a-eda4-4eb5-921b-ba05453a0466",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "CONTAINER_URL = \"https://<replace-account-name>.blob.core.windows.net/azstoragetorchintro\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4193a0ba-9a87-40f4-90d2-c8e8571e3a21",
+   "metadata": {},
+   "source": [
+    "# Loading and saving PyTorch models\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "69b2c490-f8c5-4127-b5a6-38a292924ad8",
+   "metadata": {},
+   "source": [
+    "## Loading a model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8883fc9c-d3a2-409f-9c21-dd3d2b054d0c",
+   "metadata": {},
+   "source": [
+    "The core interfaces for loading a PyTorch model is the `torch.load()` function. Say we had model weights stored locally in the local directory `local-models`, we can load the model weights, using `torch.load()` passing in the name of the file or a file-like object from `open()`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "301074fa-8fc6-4ed0-9250-d16c479fad77",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "\n",
+    "# Load from string of filename \n",
+    "state_dict = torch.load(\"local-models/resnet18_weights.pth\", weights_only=True)\n",
+    "\n",
+    "# Load from file-like object\n",
+    "with open(\"local-models/resnet18_weights.pth\", \"rb\") as f:\n",
+    "    state_dict = torch.load(f, weights_only=True)\n",
+    "\n",
+    "print(state_dict)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4cb5f25b-66d5-4641-8c11-8134db481bb2",
+   "metadata": {},
+   "source": [
+    "These can then be loaded directly into the model:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ebedf1d-d262-410d-8725-66657c871e5f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torchvision.models\n",
+    "\n",
+    "resnet_model = torchvision.models.resnet18()\n",
+    "resnet_model.load_state_dict(state_dict)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d29e04ce-4372-4c9b-b27e-af972c8ee2ae",
+   "metadata": {},
+   "source": [
+    "`azstoragetorch` offers the `BlobIO` file-like object to easily load the model weights from a blob in Azure Blob Storage as if you were loading the models locally from disk. Just provide the URL to the blob and `rb` as the mode (just like you would for `open()`):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60e69113-ff56-4847-bae1-ca2d45639e7c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from azstoragetorch.io import BlobIO\n",
+    "\n",
+    "with BlobIO(f\"{CONTAINER_URL}/models/resnet18_weights.pth\", \"rb\") as f:\n",
+    "    state_dict = torch.load(f, weights_only=True)\n",
+    "    print(state_dict)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2a2efefc-f020-43fe-89ef-42a6299eae52",
+   "metadata": {},
+   "source": [
+    "## Save a model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "606319c0-d85f-4974-91b7-c30d4b3f1d43",
+   "metadata": {},
+   "source": [
+    "PyTorch offers the `torch.save()` for saving a model. It allows you to save models locally:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "05153d7c-ea72-42c3-ac2c-736b81d2e4e9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Save by filename\n",
+    "torch.save(resnet_model.state_dict(), \"local-models/resnet18_weights_saved.pth\")\n",
+    "\n",
+    "# Or save using file-like object\n",
+    "with open(\"local-models/resnet18_weights_saved_by_filelike.pth\", \"wb\") as f:\n",
+    "    torch.save(resnet_model.state_dict(), f)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e43e3070-2b00-450a-a6a4-7f51223418eb",
+   "metadata": {},
+   "source": [
+    "And we can see the locally saved copies of the weights:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "376dcf06-a938-45ea-98a2-65a443ed02fa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.listdir(\"local-models\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2578689b-aed3-4b06-8c41-df536f14ee2c",
+   "metadata": {},
+   "source": [
+    "To upload the weights to Azure Blob Storage, we can use `BlobIO` again but this time in write mode (i.e., `wb`):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8d6ec072-d5f0-4a62-96c1-e6ca210ca591",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with BlobIO(f\"{CONTAINER_URL}/models/resnet18_weights_saved.pth\", \"wb\") as f:\n",
+    "    torch.save(resnet_model.state_dict(), f)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "91972e03-5b3b-44ff-849d-1f04238477a4",
+   "metadata": {},
+   "source": [
+    "# PyTorch datasets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14f5801d-45c0-421a-9582-9ca5fc27ed42",
+   "metadata": {},
+   "source": [
+    "`azstoragetorch` offers a map-style dataset, `BlobDataset`, and an iterable-sytle dataset, `IterableBlobDataset`. To instantiate a dataset, use on of their class methods. For example, use `from_container_url()` to build the dataset by listing blobs in an Azure Storage container:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b1a4df28-c1d0-479d-b3b0-3f14adcf3dc5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from azstoragetorch.datasets import BlobDataset\n",
+    "\n",
+    "dataset = BlobDataset.from_container_url(CONTAINER_URL, prefix=\"datasets/caltech101\")\n",
+    "print(len(dataset))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6cc7c96e-0a9f-4158-a63c-0a5a3003f608",
+   "metadata": {},
+   "source": [
+    "Data samples in the dataset map directly to blobs in the container. The default return value from datasets are dictionary representations of the blob. For example, we can access an arbitrary sample from our map-style dataset:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "91bfc034-ec4c-4cbb-b3bb-2ab584831d7a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sample = dataset[4827]\n",
+    "print(sample)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f44bd008-e1c3-49a1-93e4-f31e0e494fde",
+   "metadata": {},
+   "source": [
+    "And the `data` of the sample can be rendered into an image:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ff5d2dc5-656c-4cff-9c3a-cbf89121cae4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from PIL import Image\n",
+    "import io\n",
+    "\n",
+    "img = Image.open(io.BytesIO(sample[\"data\"]))\n",
+    "display(img)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c23d2141-6858-4713-bd4d-b60e3ca407c6",
+   "metadata": {},
+   "source": [
+    "Furthermore, these datasets can be directly provided to a PyTorch `DataLoader`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7548a21b-3d67-4b9c-8285-7dbd6ed0cfa2",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "from torch.utils.data import DataLoader\n",
+    "\n",
+    "loader = DataLoader(dataset)\n",
+    "for batch in loader:\n",
+    "    print(batch)\n",
+    "    break"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee3722cf-7bc0-4f2c-b9be-9a96ee9e9c8c",
+   "metadata": {},
+   "source": [
+    "However, this is likely not the format that a PyTorch model will expect. Specifically, it will want it as a `torch.Tensor`. This can be converted using a `transform` callable:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b801b39c-e024-461c-b91c-c0e6d1748469",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torchvision.transforms\n",
+    "from PIL import Image\n",
+    "\n",
+    "# Based on recommendation from PyTorch:\n",
+    "# https://pytorch.org/hub/pytorch_vision_resnet/\n",
+    "def blob_to_category_and_tensor(blob):\n",
+    "    with blob.reader() as f:\n",
+    "        img = Image.open(f).convert(\"RGB\")\n",
+    "        img_transform = torchvision.transforms.Compose([\n",
+    "            torchvision.transforms.Resize(256),\n",
+    "            torchvision.transforms.CenterCrop(224),\n",
+    "            torchvision.transforms.ToTensor(),\n",
+    "            torchvision.transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),\n",
+    "        ])\n",
+    "        img_tensor = img_transform(img)\n",
+    "    # Get second to last component of blob name which will be the image category. For example:\n",
+    "    # blob.blob_name -> datasets/caltech101/dalmatian/image_0001.jpg\n",
+    "    # category -> dalmatian\n",
+    "    category = blob.blob_name.split(\"/\")[-2]\n",
+    "    return category, img_tensor\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7fdbf299-6914-4203-b21d-9eb3e0925605",
+   "metadata": {},
+   "source": [
+    "We can now provide this transform to the dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "80cc2bd6-1a5a-4a18-a5f1-cec95f1490e7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from azstoragetorch.datasets import IterableBlobDataset\n",
+    "\n",
+    "iterable_dataset = IterableBlobDataset.from_container_url(\n",
+    "    CONTAINER_URL,\n",
+    "    prefix=\"datasets/caltech101/dalmatian/\",\n",
+    "    transform=blob_to_category_and_tensor\n",
+    ")\n",
+    "print(next(iter(iterable_dataset)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4630192-a28b-40bc-a357-c12d8be4bc94",
+   "metadata": {},
+   "source": [
+    "We can run the resnet18 model from before in `eval()` mode to double check our transformations "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e417112-3426-45f1-b30b-6c68a9658aab",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "from torchvision.models import ResNet18_Weights\n",
+    "CATEGORIES = ResNet18_Weights.DEFAULT.meta[\"categories\"]\n",
+    "\n",
+    "loader = DataLoader(iterable_dataset, batch_size=32)\n",
+    "\n",
+    "resnet_model.eval()\n",
+    "for _, img_tensors in loader:\n",
+    "    # Output tensor of confidence scores across each image for each supported category\n",
+    "    output = resnet_model(img_tensors)\n",
+    "    # Retrieve highest value index where indexes map to category ids\n",
+    "    category_ids = torch.argmax(output, dim=1)\n",
+    "    # Print human readable category (e.g. \"dalmatian\") for index with highest value\n",
+    "    print([CATEGORIES[category_id] for category_id in category_ids])\n",
+    "    break"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8c9e08c1-767e-4d03-8e9c-2d741c704207",
+   "metadata": {},
+   "source": [
+    "# Cleanup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad76fcea-7910-4b08-af8c-6816cf27de3a",
+   "metadata": {},
+   "source": [
+    "Run the `cleanup.py` script to cleanup all resources created from this notebook. Make sure to replace `<replace-account-name-from-bootstrap>` with the Azure Storage account name you specified in the Bootstrap section.\n",
+    "\n",
+    "In running the script, it will:\n",
+    "* Delete `azstoragetorchintro` container and all blobs in container\n",
+    "* Delete `local-models` directory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6578f8cb-daff-4ec9-bd0f-c01b03906e67",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%run cleanup.py \"https://<replace-account-name-from-bootstrap>.blob.core.windows.net\""
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/samples/intro_notebook/bootstrap.py
+++ b/samples/intro_notebook/bootstrap.py
@@ -1,0 +1,140 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in the project root for
+# license information.
+# --------------------------------------------------------------------------
+import argparse
+import concurrent.futures
+import io
+import hashlib
+import os
+import shutil
+import tempfile
+import zipfile
+
+from azure.storage.blob import BlobServiceClient
+from azure.identity import DefaultAzureCredential
+import requests
+import torch
+import torchvision
+
+CONTAINER_NAME = "azstoragetorchintro"
+DATASET_PREFIX = "datasets/caltech101"
+
+ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+LOCAL_MODELS_DIR = os.path.join(ROOT_DIR, "local-models")
+
+DATASET_URL = "https://data.caltech.edu/records/mzrjq-6wc02/files/caltech-101.zip"
+DATASET_MD5 = "3138e1922a9193bfa496528edbbc45d0"
+
+
+def bootstrap(account_url):
+    container_client = create_container(account_url)
+    init_model(container_client)
+    init_dataset(container_client)
+    print(f"Set CONTAINER_URL variable in next cell to: {container_client.url}")
+
+
+def create_container(account_url):
+    blob_service_client = BlobServiceClient(
+        account_url=account_url, credential=DefaultAzureCredential()
+    )
+    container_client = blob_service_client.get_container_client(CONTAINER_NAME)
+    print(f"Creating container: {container_client.url}")
+    container_client.create_container()
+    return container_client
+
+
+def init_model(container_client):
+    model = torchvision.models.resnet18(weights="DEFAULT")
+    save_local_model(model, "resnet18_weights.pth")
+    save_model_to_blob(container_client, "resnet18_weights.pth")
+
+
+def init_dataset(container_client):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        path_to_samples = download_dataset(temp_dir)
+        print(
+            f"Uploading Caltech 101 dataset to container path: {container_client.url}/{DATASET_PREFIX}/. "
+            "This may take several minutes."
+        )
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            futures = []
+            for root, _, filenames in os.walk(path_to_samples):
+                for filename in filenames:
+                    sample_path = os.path.join(root, filename)
+                    futures.append(
+                        executor.submit(
+                            upload_data_sample, sample_path, container_client
+                        )
+                    )
+            for future in futures:
+                future.result()
+
+
+def upload_data_sample(sample_path, container_client):
+    category = get_sample_category(sample_path)
+    name = os.path.basename(sample_path)
+    blob_name = f"{DATASET_PREFIX}/{category}/{name}"
+    blob_client = container_client.get_blob_client(blob_name)
+    with open(sample_path, "rb") as f:
+        blob_client.upload_blob(f, overwrite=True)
+
+
+def get_sample_category(sample_path):
+    return os.path.basename(os.path.dirname(sample_path))
+
+
+def download_dataset(temp_dir):
+    response = requests.get(DATASET_URL)
+    response.raise_for_status()
+    content = io.BytesIO(response.content)
+    md5_hash = hashlib.md5(content.getvalue()).hexdigest()
+    assert md5_hash == DATASET_MD5, (
+        f"MD5 checksum does not match expected value: {DATASET_MD5}, got {md5_hash}"
+    )
+    with zipfile.ZipFile(content, "r") as zf:
+        zf.extractall(temp_dir)
+    dataset_tar_path = os.path.join(
+        temp_dir, "caltech-101", "101_ObjectCategories.tar.gz"
+    )
+    shutil.unpack_archive(dataset_tar_path, temp_dir)
+    dataset_dir = os.path.join(temp_dir, "101_ObjectCategories")
+    return dataset_dir
+
+
+def save_local_model(model, model_filename):
+    print(f"Saving ResNet-18 model to local directory: {LOCAL_MODELS_DIR}")
+    if not os.path.exists(LOCAL_MODELS_DIR):
+        os.makedirs(LOCAL_MODELS_DIR)
+    local_model_file = os.path.join(LOCAL_MODELS_DIR, model_filename)
+    torch.save(model.state_dict(), local_model_file)
+
+
+def save_model_to_blob(container_client, model_filename):
+    blob_client = container_client.get_blob_client(f"models/{model_filename}")
+    print(f"Uploading ResNet-18 model to blob storage: {blob_client.url}")
+    local_model_filename = os.path.join(LOCAL_MODELS_DIR, model_filename)
+    with open(local_model_filename, "rb") as data:
+        blob_client.upload_blob(data, overwrite=True)
+
+
+def create_parser():
+    parser = argparse.ArgumentParser(
+        description="Bootstrap resources for azstoragetorch-intro notebook"
+    )
+    parser.add_argument(
+        "account_url",
+        help="The URL of the Azure Storage account to create resources for notebook.",
+    )
+    return parser
+
+
+def main():
+    parser = create_parser()
+    args = parser.parse_args()
+    bootstrap(args.account_url)
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/intro_notebook/cleanup.py
+++ b/samples/intro_notebook/cleanup.py
@@ -1,0 +1,66 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in the project root for
+# license information.
+# --------------------------------------------------------------------------
+import argparse
+import os
+import shutil
+
+from azure.storage.blob import BlobServiceClient
+from azure.identity import DefaultAzureCredential
+
+CONTAINER_NAME = "azstoragetorchintro"
+
+ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+LOCAL_MODELS_DIR = os.path.join(ROOT_DIR, "local-models")
+
+
+def cleanup(account_url):
+    delete_local_models_dir()
+    delete_container(account_url)
+
+
+def delete_local_models_dir():
+    if os.path.exists(LOCAL_MODELS_DIR):
+        print(f"Deleting local models directory: {LOCAL_MODELS_DIR}")
+        shutil.rmtree(LOCAL_MODELS_DIR)
+    else:
+        print(
+            f"Skipping deletion of local models directory: {LOCAL_MODELS_DIR}. It does not exist."
+        )
+
+
+def delete_container(account_url):
+    blob_service_client = BlobServiceClient(
+        account_url=account_url, credential=DefaultAzureCredential()
+    )
+    container_client = blob_service_client.get_container_client(CONTAINER_NAME)
+    if container_client.exists():
+        print(f"Deleting container: {container_client.url}")
+        container_client.delete_container()
+    else:
+        print(
+            f"Skipping deletion of container: {container_client.url}. It does not exist."
+        )
+
+
+def create_parser():
+    parser = argparse.ArgumentParser(
+        description="Clean up resources from azstoragetorch-intro notebook"
+    )
+    parser.add_argument(
+        "account_url",
+        help="The URL of the Azure Storage account notebook resources were created in.",
+    )
+    return parser
+
+
+def main():
+    parser = create_parser()
+    args = parser.parse_args()
+    cleanup(args.account_url)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This is the notebook used for the demo at Build 2025 with the following deviations:
* Include `bootstrap.py` and `cleanup.py` scripts and sections to create and delete resources for notebook
* Removed Phi model portion of notebook because it is too large in size (20+ GB) for the purpose of introducing the library.

Also added links to the samples and notebook as part of the `README` for better discoverability.